### PR TITLE
Remove core.remove_detached_inventory

### DIFF
--- a/builtin/game/detached_inventory.lua
+++ b/builtin/game/detached_inventory.lua
@@ -17,8 +17,3 @@ function core.create_detached_inventory(name, callbacks, player_name)
 	core.detached_inventories[name] = stuff
 	return core.create_detached_inventory_raw(name, player_name)
 end
-
-function core.remove_detached_inventory(name)
-	core.detached_inventories[name] = nil
-	return core.remove_detached_inventory_raw(name)
-end

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2865,8 +2865,6 @@ and `minetest.auth_reload` call the authetification handler.
       Note that this parameter is mostly just a workaround and will be removed
       in future releases.
     * Creates a detached inventory. If it already exists, it is cleared.
-* `minetest.remove_detached_inventory(name)`
-    * Returns a `boolean` indicating whether the removal succeeded.
 * `minetest.do_item_eat(hp_change, replace_with_item, poison, itemstack, user, pointed_thing)`:
    returns left over ItemStack
     * See `minetest.item_eat` and `minetest.register_on_item_eat`


### PR DESCRIPTION
This PR needs testing. The `core.remove_detached_inventory` function is broken because `core.remove_detached_inventory_raw` doesn't exist.
