### PR TITLE
Shaderless transparency examples

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -805,6 +805,13 @@ autoscale_mode (Autoscaling mode) enum disable disable,enable,force
 #    A restart is required after changing this.
 show_entity_selectionbox (Show entity selection boxes) bool false
 
+[***Transparency]
+transparency_use_coverage () bool false
+transparency_no_depth () bool false
+transparency_sort_chunks () bool true
+transparency_sort_materials () bool false
+
+
 [*Menus]
 
 #    Use a cloud animation for the main menu background.

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3924,8 +3924,10 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	*/
 
 	if (m_cache_enable_fog) {
+		auto fog_color = sky->getBgColor();
+		fog_color.setAlpha(0);
 		driver->setFog(
-				sky->getBgColor(),
+				fog_color,
 				video::EFT_FOG_LINEAR,
 				runData.fog_range * m_cache_fog_start,
 				runData.fog_range * 1.0,

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -1164,6 +1164,20 @@ MapBlockMesh::MapBlockMesh(MeshMakeData *data, v3s16 camera_offset):
 			} else {
 				p.layer.applyMaterialOptions(material);
 			}
+			static bool use_alpha_to_coverage = g_settings->getFlag("transparency_use_coverage");
+			static bool disable_z_write = g_settings->getFlag("transparency_no_depth");
+			switch (p.layer.material_type) {
+			case TILE_MATERIAL_ALPHA:
+			case TILE_MATERIAL_LIQUID_TRANSPARENT:
+			case TILE_MATERIAL_WAVING_LIQUID_TRANSPARENT:
+				if (use_alpha_to_coverage)
+					material.AntiAliasing |= video::EAAM_ALPHA_TO_COVERAGE;
+				if (disable_z_write)
+					material.ZWriteEnable = video::EZW_OFF;
+				break;
+			default:
+				break;
+			}
 
 			scene::SMesh *mesh = (scene::SMesh *)m_mesh[layer];
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -276,6 +276,11 @@ void set_default_settings()
 	settings->setDefault("enable_waving_leaves", "false");
 	settings->setDefault("enable_waving_plants", "false");
 
+	// Transparency
+	settings->setDefault("transparency_use_coverage", "false");
+	settings->setDefault("transparency_no_depth", "false");
+	settings->setDefault("transparency_sort_chunks", "true");
+	settings->setDefault("transparency_sort_materials", "false");
 
 	// Input
 	settings->setDefault("invert_mouse", "false");

--- a/src/util/numeric.cpp
+++ b/src/util/numeric.cpp
@@ -123,18 +123,18 @@ bool isBlockInSight(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
 	v3f blockpos_relative = blockpos - camera_pos;
 
 	// Total distance
-	f32 d = MYMAX(0, blockpos_relative.getLength() - block_max_radius);
+	f32 d = blockpos_relative.getLength();
 
 	if (distance_ptr)
 		*distance_ptr = d;
 
 	// If block is far away, it's not in sight
-	if (d > range)
+	if (d > range + block_max_radius)
 		return false;
 
 	// If block is (nearly) touching the camera, don't
 	// bother validating further (that is, render it anyway)
-	if (d == 0)
+	if (d <= block_max_radius)
 		return true;
 
 	// Adjust camera position, for purposes of computing the angle,


### PR DESCRIPTION
Shaderless transparency improvements. Controlled via boolean options:

 * transparency_use_coverage (only works with multisampling)
 * transparency_no_depth (okay if all transparent objects are pale)
 * transparency_sort_chunks (ensure correct interchunk transparency)
 * transparency_sort_materials (prevent intrachunk flicker)
