### PR TITLE
Order-independent transparency

### DIFF
--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -91,8 +91,17 @@ void main(void)
 	// Note: clarity = (1 - fogginess)
 	float clarity = clamp(fogShadingParameter
 		- fogShadingParameter * length(eyeVec), 0.0, 1.0);
+#if MATERIAL_TYPE == TILE_MATERIAL_ALPHA || MATERIAL_TYPE == TILE_MATERIAL_LIQUID_TRANSPARENT || MATERIAL_TYPE == TILE_MATERIAL_WAVING_LIQUID_TRANSPARENT
+	col = mix(skyBgColor, col, clarity);
+	col = vec4(col.rgb, base.a);
+	float transparency = 1.0 - col.a * clarity;
+	float weight = col.a * gl_FragCoord.w;
+	gl_FragData[0] = vec4(col.rgb * weight, transparency);
+	gl_FragData[1] = vec4(weight, 0.0, 0.0, 0.0);
+#else
 	col = mix(skyBgColor, col, clarity);
 	col = vec4(col.rgb, base.a);
 
 	gl_FragColor = col;
+#endif
 }

--- a/client/shaders/oit_merge/opengl_fragment.glsl
+++ b/client/shaders/oit_merge/opengl_fragment.glsl
@@ -1,0 +1,20 @@
+uniform sampler2D baseTexture;
+uniform sampler2D normalTexture;
+
+#define colorImage baseTexture
+#define alphaImage normalTexture
+
+varying mediump vec2 varTexCoord;
+
+void main(void)
+{
+	vec2 uv = varTexCoord.st;
+	vec4 ca = texture2D(colorImage, uv);
+	float accum = texture2D(alphaImage, uv).r;
+	if (accum == 0.0) {
+		discard;
+	}
+	vec3 color = ca.rgb / accum;
+	float alpha = 1.0 - ca.a;
+	gl_FragColor = vec4(color, 1.0) * alpha;
+}

--- a/client/shaders/oit_merge/opengl_vertex.glsl
+++ b/client/shaders/oit_merge/opengl_vertex.glsl
@@ -1,0 +1,7 @@
+varying mediump vec2 varTexCoord;
+
+void main(void)
+{
+	varTexCoord = inTexCoord0.xy;
+	gl_Position = inVertexPosition;
+}

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -52,6 +52,7 @@ set(client_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/mesh.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/mesh_generator_thread.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/minimap.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/oit.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/particles.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/renderingengine.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/shader.cpp

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -30,6 +30,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/basic_macros.h"
 #include <algorithm>
 #include "client/renderingengine.h"
+#include "client/oit.h"
 
 // struct MeshBufListList
 void MeshBufListList::clear()
@@ -385,6 +386,9 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 	core::matrix4 m; // Model matrix
 	v3f offset = intToFloat(m_camera_offset, BS);
 
+	if (is_transparent_pass)
+		RenderingEngine::get_instance()->oit->preRender();
+
 	// Render all layers in order
 	for (auto &lists : drawbufs.lists) {
 		for (MeshBufList &list : lists) {
@@ -409,6 +413,10 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 			}
 		}
 	}
+
+	if (is_transparent_pass)
+		RenderingEngine::get_instance()->oit->postRender();
+
 	g_profiler->avg(prefix + "draw meshes [ms]", draw.stop(true));
 
 	// Log only on solid pass because values are the same

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -386,9 +386,6 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 	core::matrix4 m; // Model matrix
 	v3f offset = intToFloat(m_camera_offset, BS);
 
-	if (is_transparent_pass)
-		RenderingEngine::get_instance()->oit->preRender();
-
 	// Render all layers in order
 	for (auto &lists : drawbufs.lists) {
 		for (MeshBufList &list : lists) {
@@ -413,9 +410,6 @@ void ClientMap::renderMap(video::IVideoDriver* driver, s32 pass)
 			}
 		}
 	}
-
-	if (is_transparent_pass)
-		RenderingEngine::get_instance()->oit->postRender();
 
 	g_profiler->avg(prefix + "draw meshes [ms]", draw.stop(true));
 

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -1165,6 +1165,18 @@ MapBlockMesh::MapBlockMesh(MeshMakeData *data, v3s16 camera_offset):
 				p.layer.applyMaterialOptions(material);
 			}
 
+			switch (p.layer.material_type) {
+			case TILE_MATERIAL_ALPHA:
+			case TILE_MATERIAL_LIQUID_TRANSPARENT:
+			case TILE_MATERIAL_WAVING_LIQUID_TRANSPARENT:
+				material.ZWriteEnable = video::EZW_OFF;
+				material.BlendOperation = video::EBO_ADD;
+				material.MaterialTypeParam = video::pack_textureBlendFuncSeparate(video::EBF_ONE, video::EBF_ONE, video::EBF_ZERO, video::EBF_SRC_ALPHA);
+				break;
+			default:
+				break;
+			}
+
 			scene::SMesh *mesh = (scene::SMesh *)m_mesh[layer];
 
 			scene::SMeshBuffer *buf = new scene::SMeshBuffer();

--- a/src/client/oit.cpp
+++ b/src/client/oit.cpp
@@ -1,0 +1,121 @@
+#include "oit.h"
+#include "client/client.h"
+#include "client/shader.h"
+#include "client/tile.h"
+#define GL_GLEXT_PROTOTYPES
+#include <GL/gl.h>
+#include <GL/glext.h>
+
+using namespace video;
+
+static constexpr ECOLOR_FORMAT depth_format = ECF_D24S8;
+static constexpr ECOLOR_FORMAT layer_formats[] = {
+	ECF_A16B16G16R16F,
+	ECF_R16F,
+};
+static constexpr auto layer_count = sizeof(layer_formats) / sizeof(layer_formats[0]);
+
+void RenderingOIT::OnRenderPassPreRender(scene::E_SCENE_NODE_RENDER_PASS renderPass) {
+	if (renderPass == scene::ESNRP_TRANSPARENT)
+		preRender();
+}
+
+void RenderingOIT::OnRenderPassPostRender(scene::E_SCENE_NODE_RENDER_PASS renderPass) {
+	if (renderPass == scene::ESNRP_TRANSPARENT)
+		postRender();
+}
+
+
+RenderingOIT::RenderingOIT(IVideoDriver *_driver, Client *_client)
+	: driver(_driver)
+	, color(layer_count)
+{
+	rt = driver->addRenderTarget();
+	screensize = {-1u, -1u};
+	initMaterial(_client->getShaderSource());
+}
+
+RenderingOIT::~RenderingOIT()
+{
+	clearTextures();
+	driver->removeRenderTarget(rt);
+}
+
+void RenderingOIT::initMaterial(IShaderSource *s)
+{
+	mat.UseMipMaps = false;
+	mat.ZBuffer = false;
+	mat.setFlag(EMF_ZWRITE_ENABLE, false); // ZWriteEnable is bool on early 1.9 but E_ZWRITE on later 1.9
+	u32 shader = s->getShader("oit_merge", TILE_MATERIAL_ALPHA);
+	mat.MaterialType = s->getShaderInfo(shader).material;
+	mat.BlendOperation = EBO_ADD;
+	mat.MaterialTypeParam = pack_textureBlendFunc(EBF_ONE, EBF_ONE_MINUS_SRC_ALPHA);
+	for (int k = 0; k < layer_count; ++k) {
+		mat.TextureLayer[k].AnisotropicFilter = false;
+		mat.TextureLayer[k].BilinearFilter = false;
+		mat.TextureLayer[k].TrilinearFilter = false;
+		mat.TextureLayer[k].TextureWrapU = ETC_CLAMP_TO_EDGE;
+		mat.TextureLayer[k].TextureWrapV = ETC_CLAMP_TO_EDGE;
+	}
+}
+
+void RenderingOIT::initTextures()
+{
+	depth = driver->addRenderTargetTexture(screensize, "oit_depth", depth_format);
+	for (int k = 0; k < layer_count; k++) {
+		char name[32];
+		snprintf(name, sizeof(name), "oit_layer_%d", k);
+		color[k] = driver->addRenderTargetTexture(screensize, name, layer_formats[k]);
+		mat.TextureLayer[k].Texture = color[k];
+	}
+	color.set_used(layer_count);
+	rt->setTexture(color, depth);
+}
+
+void RenderingOIT::clearTextures()
+{
+	rt->setTexture(nullptr, nullptr);
+	for (int k = 0; k < layer_count; k++)
+		driver->removeTexture(color[k]);
+	color.set_used(0);
+	driver->removeTexture(depth);
+}
+
+void RenderingOIT::preRender() {
+	v2u32 ss = driver->getScreenSize();
+	if (screensize != ss) {
+		clearTextures();
+		screensize = ss;
+		initTextures();
+	}
+	int fb_main, fb_my, fb_read;
+	glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &fb_main);
+	driver->setRenderTargetEx(rt, ECBF_COLOR | ECBF_DEPTH, SColor(255, 0, 0, 0));
+	glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &fb_my);
+	glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &fb_read);
+	glBindFramebuffer(GL_READ_FRAMEBUFFER, fb_main);
+	int err0 = glGetError();
+	glBlitFramebuffer(0, 0, ss.X, ss.Y, 0, 0, ss.X, ss.Y, GL_DEPTH_BUFFER_BIT, GL_NEAREST);
+	int err1 = glGetError();
+	glBindFramebuffer(GL_READ_FRAMEBUFFER, fb_read);
+	int err2 = glGetError();
+	if (err0 || err1 || err2)
+		printf("%d/%d/%d: %d/%d/%d\n", fb_main, fb_my, fb_read, err0, err1, err2);
+}
+
+void RenderingOIT::postRender() {
+	static const S3DVertex vertices[4] = {
+			S3DVertex(1.0, -1.0, 0.0, 0.0, 0.0, -1.0,
+					SColor(255, 0, 255, 255), 1.0, 0.0),
+			S3DVertex(-1.0, -1.0, 0.0, 0.0, 0.0, -1.0,
+					SColor(255, 255, 0, 255), 0.0, 0.0),
+			S3DVertex(-1.0, 1.0, 0.0, 0.0, 0.0, -1.0,
+					SColor(255, 255, 255, 0), 0.0, 1.0),
+			S3DVertex(1.0, 1.0, 0.0, 0.0, 0.0, -1.0,
+					SColor(255, 255, 255, 255), 1.0, 1.0),
+	};
+	static const u16 indices[6] = {0, 1, 2, 2, 3, 0};
+	driver->setRenderTargetEx(nullptr, 0);
+	driver->setMaterial(mat);
+	driver->drawVertexPrimitiveList(&vertices, 4, &indices, 2);
+}

--- a/src/client/oit.cpp
+++ b/src/client/oit.cpp
@@ -2,9 +2,6 @@
 #include "client/client.h"
 #include "client/shader.h"
 #include "client/tile.h"
-#define GL_GLEXT_PROTOTYPES
-#include <GL/gl.h>
-#include <GL/glext.h>
 
 using namespace video;
 

--- a/src/client/oit.h
+++ b/src/client/oit.h
@@ -9,10 +9,13 @@ class IShaderSource;
 class RenderingOIT: public scene::ILightManager
 {
 protected:
+	IrrlichtDevice *device = nullptr;
 	video::IVideoDriver *driver = nullptr;
 	core::array<video::ITexture *> color;
+	video::ITexture *solid = nullptr;
 	video::ITexture *depth = nullptr;
-	video::IRenderTarget *rt = nullptr;
+	video::IRenderTarget *rt_solid = nullptr;
+	video::IRenderTarget *rt_transparent = nullptr;
 	video::SMaterial mat;
 	core::dimension2du screensize = {0, 0};
 
@@ -20,17 +23,9 @@ protected:
 	void initTextures();
 	void clearTextures();
 
-	void beforeSolid();
-	void afterSolid();
-	void beforeTransparent();
-	void afterTransparent();
-
 public:
-	void preRender();
-	void postRender();
-
-	void OnPreRender(core::array<scene::ISceneNode*> & lightList) override {}
-	void OnPostRender(void) override {}
+	void OnPreRender(core::array<scene::ISceneNode*> & lightList) override;
+	void OnPostRender(void) override;
 
 	void OnRenderPassPreRender(scene::E_SCENE_NODE_RENDER_PASS renderPass) override;
 	void OnRenderPassPostRender(scene::E_SCENE_NODE_RENDER_PASS renderPass) override;
@@ -38,6 +33,6 @@ public:
 	void OnNodePreRender(scene::ISceneNode* node) override {}
 	void OnNodePostRender(scene::ISceneNode* node) override {}
 
-	RenderingOIT(video::IVideoDriver *_driver, Client *_client);
+	RenderingOIT(IrrlichtDevice *_device, Client *_client);
 	~RenderingOIT() override;
 };

--- a/src/client/oit.h
+++ b/src/client/oit.h
@@ -1,0 +1,43 @@
+#pragma once
+#include "irrlichttypes_extrabloated.h"
+#include <ILightManager.h>
+
+class Client;
+class Hud;
+class IShaderSource;
+
+class RenderingOIT: public scene::ILightManager
+{
+protected:
+	video::IVideoDriver *driver = nullptr;
+	core::array<video::ITexture *> color;
+	video::ITexture *depth = nullptr;
+	video::IRenderTarget *rt = nullptr;
+	video::SMaterial mat;
+	core::dimension2du screensize = {0, 0};
+
+	void initMaterial(IShaderSource *s);
+	void initTextures();
+	void clearTextures();
+
+	void beforeSolid();
+	void afterSolid();
+	void beforeTransparent();
+	void afterTransparent();
+
+public:
+	void preRender();
+	void postRender();
+
+	void OnPreRender(core::array<scene::ISceneNode*> & lightList) override {}
+	void OnPostRender(void) override {}
+
+	void OnRenderPassPreRender(scene::E_SCENE_NODE_RENDER_PASS renderPass) override;
+	void OnRenderPassPostRender(scene::E_SCENE_NODE_RENDER_PASS renderPass) override;
+
+	void OnNodePreRender(scene::ISceneNode* node) override {}
+	void OnNodePostRender(scene::ISceneNode* node) override {}
+
+	RenderingOIT(video::IVideoDriver *_driver, Client *_client);
+	~RenderingOIT() override;
+};

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -686,11 +686,12 @@ void RenderingEngine::_initialize(Client *client, Hud *hud)
 	const std::string &draw_mode = g_settings->get("3d_mode");
 	core.reset(createRenderingCore(draw_mode, m_device, client, hud));
 	core->initialize();
-	oit.reset(new RenderingOIT(m_device->getVideoDriver(), client));
+	oit.reset(new RenderingOIT(m_device, client));
 }
 
 void RenderingEngine::_finalize()
 {
+	oit.reset();
 	core.reset();
 }
 

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -36,6 +36,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "inputhandler.h"
 #include "gettext.h"
 #include "../gui/guiSkin.h"
+#include "oit.h"
 
 #if !defined(_WIN32) && !defined(__APPLE__) && !defined(__ANDROID__) && \
 		!defined(SERVER) && !defined(__HAIKU__) && !defined(__IOS__)
@@ -685,6 +686,7 @@ void RenderingEngine::_initialize(Client *client, Hud *hud)
 	const std::string &draw_mode = g_settings->get("3d_mode");
 	core.reset(createRenderingCore(draw_mode, m_device, client, hud));
 	core->initialize();
+	oit.reset(new RenderingOIT(m_device->getVideoDriver(), client));
 }
 
 void RenderingEngine::_finalize()

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -34,6 +34,7 @@ class Hud;
 class Minimap;
 
 class RenderingCore;
+class RenderingOIT;
 
 class RenderingEngine
 {
@@ -138,6 +139,8 @@ public:
 
 	static std::vector<core::vector3d<u32>> getSupportedVideoModes();
 	static std::vector<irr::video::E_DRIVER_TYPE> getSupportedVideoDrivers();
+
+	std::unique_ptr<RenderingOIT> oit;
 
 private:
 	void _draw_load_screen(const std::wstring &text, gui::IGUIEnvironment *guienv,

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -543,6 +543,7 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 	case TILE_MATERIAL_LIQUID_TRANSPARENT:
 	case TILE_MATERIAL_WAVING_LIQUID_TRANSPARENT:
 		shaderinfo.base_material = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
+		shaderinfo.base_material = video::EMT_ONETEXTURE_BLEND;
 		break;
 	case TILE_MATERIAL_BASIC:
 	case TILE_MATERIAL_PLAIN:


### PR DESCRIPTION
This PR adds order-independent transparency to fix translucency issues once and for all. Requires shaders.

## To do

- [ ] Make optional
- [ ] Support clouds
- [ ] Support stars
- [ ] Support whatever else
- [ ] Test everything
- [ ] Fix after testing
- [ ] Test again

## How to test

Build with Irrlicht 1.9. Run MC with shaders enabled. Look at translucent nodes through translucent nodes.