### PR TITLE
[Add] data extraction rules

### DIFF
--- a/build/android/app/src/main/AndroidManifest.xml
+++ b/build/android/app/src/main/AndroidManifest.xml
@@ -34,7 +34,8 @@
 		android:requestLegacyExternalStorage="true"
 		android:resizeableActivity="false"
 		android:roundIcon="@mipmap/ic_launcher_round"
-		tools:ignore="UnusedAttribute">
+		tools:ignore="UnusedAttribute"
+		android:dataExtractionRules="@xml/data_extraction_rules">
 
 		<meta-data
 			android:name="android.max_aspect"

--- a/build/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/build/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+
+    </cloud-backup>
+</data-extraction-rules>


### PR DESCRIPTION
Add data extraction rules. 

fullBackupContent is deprecated from Android 12. Adding a new resource (dataExtractionRules with the needed @xml resource) for future cloud backups and device transfers.