### PR TITLE
Add read-only settings API to SSCSM (attempt 2)

### DIFF
--- a/builtin/client/sscsm.lua
+++ b/builtin/client/sscsm.lua
@@ -219,6 +219,26 @@ do
 		t[k] = safe_funcs[func] or func
 	end
 
+	local core_settings = core.settings
+	local sub = string.sub
+	local function setting_safe(key)
+		return type(key) == "string" and sub(key, 1, 7) ~= "secure." and
+			key ~= "password"
+	end
+
+	t.settings = {
+		get = function(_, key)
+			if setting_safe(key) then
+				return core_settings:get(key)
+			end
+		end,
+		get_bool = function(_, key, default)
+			if setting_safe(key) then
+				return core_settings:get_bool(key, default)
+			end
+		end,
+	}
+
 	env:set_copy("minetest", t)
 end
 


### PR DESCRIPTION
I still prefer the first attempt as it means SSCSMs can't mess with settings if they somehow manage to escape the SSCSM sandbox.

Closes #80