### PR TITLE
formspec_escape stability improvement

### DIFF
--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -249,6 +249,7 @@ function math.factorial(x)
 end
 
 function core.formspec_escape(text)
+        text = tostring(text)
 	if text ~= nil then
 		text = text:gsub("\\", "\\\\")
 		text = text:gsub("%]", "\\]")


### PR DESCRIPTION
formspec_escape causes server crash, when `text` argument is a number. `tostring(text)` prevents this