### PR TITLE
Use Irrlicht with SDL device for github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -299,14 +299,14 @@ jobs:
 
       - name: Irrlicht
         run: |
-          git clone --depth 1 -b cmake https://github.com/deveee/Irrlicht irrlicht
+          git clone --depth 1 -b cmake https://github.com/MoNTE48/Irrlicht irrlicht
           cd irrlicht
           cmake ${{matrix.config.generator}}  `
           -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}\vcpkg\scripts\buildsystems\vcpkg.cmake"  `
           -DCMAKE_BUILD_TYPE=Release .
           cmake --build . -j --config Release
           cd ..
-          
+
       - name: CMake
         run: |
           cmake ${{matrix.config.generator}}  `

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -299,7 +299,7 @@ jobs:
 
       - name: Irrlicht
         run: |
-          git clone --depth 1 -b cmake https://github.com/MoNTE48/Irrlicht irrlicht
+          git clone --depth 1 -b SDL2 https://github.com/MoNTE48/Irrlicht irrlicht
           cd irrlicht
           cmake ${{matrix.config.generator}}  `
           -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}\vcpkg\scripts\buildsystems\vcpkg.cmake"  `

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,7 @@ jobs:
         run: |
           source ./util/ci/common.sh
           install_linux_deps g++-10
+          build_linux_deps
 
       - name: Build
         run: |
@@ -100,6 +101,7 @@ jobs:
         run: |
           source ./util/ci/common.sh
           install_linux_deps clang-11 valgrind libluajit-5.1-dev
+          build_linux_deps
 
       - name: Build
         run: |
@@ -262,7 +264,7 @@ jobs:
     env:
       VCPKG_VERSION: a42af01b72c28a8e1d7b48107b33e4f286a55ef6
 #                    2023.11.20
-      vcpkg_packages: irrlicht zlib curl[winssl] openal-soft libvorbis libogg sqlite3 freetype luajit gmp jsoncpp
+      vcpkg_packages: zlib curl[winssl] openal-soft libvorbis libogg sqlite3 freetype luajit gmp jsoncpp libpng libjpeg-turbo sdl2
     strategy:
       fail-fast: false
       matrix:
@@ -295,12 +297,27 @@ jobs:
           vcpkgGitCommitId: ${{ env.VCPKG_VERSION }}
           vcpkgTriplet: ${{ matrix.config.vcpkg_triplet }}
 
+      - name: Irrlicht
+        run: |
+          git clone --depth 1 -b cmake https://github.com/deveee/Irrlicht irrlicht
+          cd irrlicht
+          cmake ${{matrix.config.generator}}  `
+          -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}\vcpkg\scripts\buildsystems\vcpkg.cmake"  `
+          -DCMAKE_BUILD_TYPE=Release .
+          cmake --build . -j --config Release
+          cd ..
+          
       - name: CMake
         run: |
           cmake ${{matrix.config.generator}}  `
           -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}\vcpkg\scripts\buildsystems\vcpkg.cmake"  `
           -DCMAKE_BUILD_TYPE=Release  `
           -DENABLE_POSTGRESQL=OFF  `
+          -DUSE_SDL=1  `
+          -DIRRLICHT_LIBRARY="${{ github.workspace }}\irrlicht\Release\irrlicht.lib"  `
+          -DIRRLICHT_INCLUDE_DIR="${{ github.workspace }}\irrlicht\include"  `
+          -DCMAKE_C_FLAGS="-DNO_IRR_COMPILE_WITH_OGLES2_ -DNO_IRR_COMPILE_WITH_DIRECT3D_9_ -DNO_IRR_COMPILE_WITH_DIRECTINPUT_JOYSTICK_ -D_IRR_STATIC_LIB_"  `
+          -DCMAKE_CXX_FLAGS="-DNO_IRR_COMPILE_WITH_OGLES2_ -DNO_IRR_COMPILE_WITH_DIRECT3D_9_ -DNO_IRR_COMPILE_WITH_DIRECTINPUT_JOYSTICK_ -D_IRR_STATIC_LIB_"  `
           -DRUN_IN_PLACE=${{ contains(matrix.type, 'portable') }} .
 
       - name: Build

--- a/.github/workflows/cpp_lint.yml
+++ b/.github/workflows/cpp_lint.yml
@@ -48,6 +48,7 @@ jobs:
         sudo apt-get install clang-tidy-11 -qyy
         source ./util/ci/common.sh
         install_linux_deps
+        build_linux_deps
 
     - name: Run clang-tidy
       run: |

--- a/Windows/Start.sh
+++ b/Windows/Start.sh
@@ -43,7 +43,7 @@ cmake ../ \
 	-DIRRLICHT_LIBRARY="$DEPS_ROOT/irrlicht/lib/libIrrlicht.a" \
 	-DIRRLICHT_INCLUDE_DIR="$DEPS_ROOT/irrlicht/include" \
 	-DSDL2_LIBRARIES="$DEPS_ROOT/sdl2/lib/libSDL2.a" \
-	-DSDL2_INCLUDE_DIR="$DEPS_ROOT/sdl2/include" \
+	-DSDL2_INCLUDE_DIRS="$DEPS_ROOT/sdl2/include" \
 	-DCURL_LIBRARY="$DEPS_ROOT/libcurl/lib/libcurl.a" \
 	-DCURL_INCLUDE_DIR="$DEPS_ROOT/libcurl/include" \
 	-DLUA_LIBRARY="$DEPS_ROOT/luajit/lib/libluajit.a" \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,7 +42,7 @@ if(USE_SDL)
 	endif()
 	if (SDL2_FOUND)
 		message(STATUS "SDL2 found.")
-		include_directories(${SDL2_INCLUDE_DIR})
+		include_directories(${SDL2_INCLUDE_DIRS})
 	else()
 		message(FATAL_ERROR "SDL2 not found.")
 	endif()
@@ -268,6 +268,12 @@ endif()
 add_definitions(-DUSE_CMAKE_CONFIG_H)
 
 if(WIN32)
+	# Irrlicht with SDL needs external libjpeg/libpng
+	if(MSVC AND BUILD_CLIENT AND USE_SDL)
+		find_package(JPEG REQUIRED)
+		find_package(PNG REQUIRED)
+	endif()
+
 	# Windows
 	if(MSVC) # MSVC Specifics
 		set(PLATFORM_LIBS dbghelp.lib ${PLATFORM_LIBS})
@@ -692,6 +698,21 @@ if(BUILD_SERVER)
 		)
 	endif()
 
+	if(USE_SDL)
+		target_link_libraries(
+			${PROJECT_NAME}server
+			${SDL2_LIBRARIES}
+		)
+		if(USE_STATIC_BUILD AND WIN32)
+			target_link_libraries(
+				${PROJECT_NAME}server
+				winmm
+				imm32
+				setupapi
+				opengl32
+			)
+		endif()
+	endif()
 	if (USE_GETTEXT)
 		target_link_libraries(${PROJECT_NAME}server ${GETTEXT_LIBRARY})
 	endif()
@@ -930,7 +951,7 @@ if(BUILD_CLIENT)
 
 	if(WIN32)
 		if(NOT VCPKG_APPLOCAL_DEPS)
-			if(DEFINED IRRLICHT_DLL)
+			if(IRRLICHT_DLL)
 				install(FILES ${IRRLICHT_DLL} DESTINATION ${BINDIR})
 			endif()
 			if(USE_GETTEXT)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -250,7 +250,7 @@ int main(int argc, char *argv[])
 	return retval;
 }
 
-#ifdef WIN32
+#if defined(WIN32) && !defined(_MSC_VER)
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 		LPSTR lpCmdLine, int nCmdShow)
 {

--- a/util/buildbot/buildwin32.sh
+++ b/util/buildbot/buildwin32.sh
@@ -41,7 +41,7 @@ leveldb_version=1.23
 zlib_version=1.2.13
 sdl_version=2.28.5
 jpeg_version=3.0.1
-png_version=1.6.41
+png_version=1.6.42
 
 mkdir -p $packagedir
 mkdir -p $libdir
@@ -126,8 +126,9 @@ if [ ! -d libpng ]; then
 		-DPNG_SHARED=OFF \
 		-DPNG_TESTS=OFF \
 		-DPNG_EXECUTABLES=OFF \
-		-DPNG_BUILD_ZLIB=ON \
-		-DZLIB_INCLUDE_DIRS="$libdir/zlib/include" \
+		-DZLIB_ROOT="$libdir/zlib" \
+		-DZLIB_LIBRARY="$libdir/zlib/lib/libz.a" \
+		-DZLIB_INCLUDE_DIR="$libdir/zlib/include" \
 		-DCMAKE_C_FLAGS_RELEASE="$CFLAGS"
 
 	cmake --build . -j$(nproc)

--- a/util/buildbot/buildwin32.sh
+++ b/util/buildbot/buildwin32.sh
@@ -40,8 +40,8 @@ luajit_version=20230221
 leveldb_version=1.23
 zlib_version=1.2.13
 sdl_version=2.28.5
-jpeg_version=3.0.0
-png_version=1.6.40
+jpeg_version=3.0.1
+png_version=1.6.42
 
 mkdir -p $packagedir
 mkdir -p $libdir
@@ -105,9 +105,9 @@ if [ ! -d libjpeg ]; then
 		-DCMAKE_BUILD_TYPE=Release \
 		-DENABLE_SHARED=OFF \
 		-DCMAKE_C_FLAGS_RELEASE="$CFLAGS"
-	
+
 	cmake --build . -j$(nproc)
-	
+
 	cd -
 fi
 
@@ -119,7 +119,7 @@ if [ ! -d libpng ]; then
 	rm libpng-$png_version.tar.gz
 	mkdir libpng/build
 	cd libpng/build
-	
+
 	cmake .. \
 		-DCMAKE_TOOLCHAIN_FILE=$toolchain_file \
 		-DCMAKE_BUILD_TYPE=Release \
@@ -129,16 +129,16 @@ if [ ! -d libpng ]; then
 		-DPNG_BUILD_ZLIB=ON \
 		-DZLIB_INCLUDE_DIRS="$libdir/zlib/include" \
 		-DCMAKE_C_FLAGS_RELEASE="$CFLAGS"
-	
+
 	cmake --build . -j$(nproc)
-	
+
 	cd -
 fi
 
 # Get irrlicht
 if [ ! -d irrlicht ]; then
 	git clone --depth 1 -b SDL2 https://github.com/MoNTE48/Irrlicht irrlicht
-	
+
 	cd irrlicht/source/Irrlicht
 
 	CC="i686-w64-mingw32-gcc" \
@@ -157,7 +157,7 @@ if [ ! -d irrlicht ]; then
 		-I$libdir/libpng/build" \
 	CXXFLAGS="$CXXFLAGS -std=gnu++17" \
 	make staticlib_win32 -j$(nproc) NDEBUG=1
-	
+
 	cd -
 fi
 

--- a/util/buildbot/buildwin32.sh
+++ b/util/buildbot/buildwin32.sh
@@ -41,7 +41,7 @@ leveldb_version=1.23
 zlib_version=1.2.13
 sdl_version=2.28.5
 jpeg_version=3.0.1
-png_version=1.6.42
+png_version=1.6.41
 
 mkdir -p $packagedir
 mkdir -p $libdir

--- a/util/buildbot/buildwin32.sh
+++ b/util/buildbot/buildwin32.sh
@@ -39,6 +39,9 @@ sqlite3_version=3.41.2
 luajit_version=20230221
 leveldb_version=1.23
 zlib_version=1.2.13
+sdl_version=2.28.5
+jpeg_version=3.0.0
+png_version=1.6.40
 
 mkdir -p $packagedir
 mkdir -p $libdir
@@ -46,8 +49,8 @@ mkdir -p $libdir
 cd $builddir
 
 # Get stuff
-[ -e $packagedir/irrlicht-$irrlicht_version.zip ] || wget http://minetest.kitsunemimi.pw/irrlicht-$irrlicht_version-win32.zip \
-	-c -O $packagedir/irrlicht-$irrlicht_version.zip
+# [ -e $packagedir/irrlicht-$irrlicht_version.zip ] || wget http://minetest.kitsunemimi.pw/irrlicht-$irrlicht_version-win32.zip \
+#	-c -O $packagedir/irrlicht-$irrlicht_version.zip
 [ -e $packagedir/zlib-$zlib_version.zip ] || wget http://minetest.kitsunemimi.pw/zlib-$zlib_version-win32.zip \
 	-c -O $packagedir/zlib-$zlib_version.zip
 [ -e $packagedir/libogg-$ogg_version.zip ] || wget http://minetest.kitsunemimi.pw/libogg-$ogg_version-win32.zip \
@@ -68,10 +71,12 @@ cd $builddir
 	-c -O $packagedir/libleveldb-$leveldb_version.zip
 [ -e $packagedir/openal_stripped.zip ] || wget http://minetest.kitsunemimi.pw/openal_stripped.zip \
 	-c -O $packagedir/openal_stripped.zip
+[ -e $packagedir/SDL2-devel-$sdl_version-mingw.zip ] || wget https://github.com/libsdl-org/SDL/releases/download/release-$sdl_version/SDL2-devel-$sdl_version-mingw.zip \
+	-c -O $packagedir/SDL2-devel-$sdl_version-mingw.zip
 
 # Extract stuff
 cd $libdir
-[ -d irrlicht ] || unzip -o $packagedir/irrlicht-$irrlicht_version.zip -d irrlicht
+# [ -d irrlicht ] || unzip -o $packagedir/irrlicht-$irrlicht_version.zip -d irrlicht
 [ -d zlib ] || unzip -o $packagedir/zlib-$zlib_version.zip -d zlib
 [ -d libogg ] || unzip -o $packagedir/libogg-$ogg_version.zip -d libogg
 [ -d libvorbis ] || unzip -o $packagedir/libvorbis-$vorbis_version.zip -d libvorbis
@@ -82,6 +87,79 @@ cd $libdir
 [ -d openal_stripped ] || unzip -o $packagedir/openal_stripped.zip
 [ -d luajit ] || unzip -o $packagedir/luajit-$luajit_version.zip -d luajit
 [ -d leveldb ] || unzip -o $packagedir/libleveldb-$leveldb_version.zip -d leveldb
+[ -d SDL2 ] || (unzip -o $packagedir/SDL2-devel-$sdl_version-mingw.zip SDL2-$sdl_version/i686-w64-mingw32/* -d SDL2 && mv SDL2/SDL2-$sdl_version/i686-w64-mingw32/* SDL2)
+
+# Get libjpeg
+if [ ! -d libjpeg ]; then
+	wget https://download.sourceforge.net/libjpeg-turbo/libjpeg-turbo-$jpeg_version.tar.gz
+	tar -xzf libjpeg-turbo-$jpeg_version.tar.gz
+	mv libjpeg-turbo-$jpeg_version libjpeg
+	rm libjpeg-turbo-$jpeg_version.tar.gz
+	mkdir libjpeg/build
+	cd libjpeg/build
+
+	cmake .. \
+		-DCMAKE_TOOLCHAIN_FILE=$toolchain_file \
+		-DCMAKE_SYSTEM_PROCESSOR=X86 \
+		-DCMAKE_INSTALL_PREFIX=/tmp \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DENABLE_SHARED=OFF \
+		-DCMAKE_C_FLAGS_RELEASE="$CFLAGS"
+	
+	cmake --build . -j$(nproc)
+	
+	cd -
+fi
+
+# Get libpng
+if [ ! -d libpng ]; then
+	wget https://download.sourceforge.net/libpng/libpng-$png_version.tar.gz
+	tar -xzf libpng-$png_version.tar.gz
+	mv libpng-$png_version libpng
+	rm libpng-$png_version.tar.gz
+	mkdir libpng/build
+	cd libpng/build
+	
+	cmake .. \
+		-DCMAKE_TOOLCHAIN_FILE=$toolchain_file \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DPNG_SHARED=OFF \
+		-DPNG_TESTS=OFF \
+		-DPNG_EXECUTABLES=OFF \
+		-DPNG_BUILD_ZLIB=ON \
+		-DZLIB_INCLUDE_DIRS="$libdir/zlib/include" \
+		-DCMAKE_C_FLAGS_RELEASE="$CFLAGS"
+	
+	cmake --build . -j$(nproc)
+	
+	cd -
+fi
+
+# Get irrlicht
+if [ ! -d irrlicht ]; then
+	git clone --depth 1 -b SDL2 https://github.com/MoNTE48/Irrlicht irrlicht
+	
+	cd irrlicht/source/Irrlicht
+
+	CC="i686-w64-mingw32-gcc" \
+	CXX="i686-w64-mingw32-g++" \
+	CPPFLAGS="$CPPFLAGS \
+		-DCMAKE_TOOLCHAIN_FILE=$toolchain_file \
+		-DNO_IRR_COMPILE_WITH_SDL_TEXTINPUT_ \
+		-DNO_IRR_COMPILE_WITH_OGLES2_ \
+		-DNO_IRR_COMPILE_WITH_DIRECT3D_9_ \
+		-I/usr/i686-w64-mingw32/include \
+		-I$libdir/SDL2/include/SDL2 \
+		-I$libdir/zlib/include \
+		-I$libdir/libjpeg \
+		-I$libdir/libjpeg/build \
+		-I$libdir/libpng \
+		-I$libdir/libpng/build" \
+	CXXFLAGS="$CXXFLAGS -std=gnu++17" \
+	make staticlib_win32 -j$(nproc) NDEBUG=1
+	
+	cd -
+fi
 
 # Get minetest
 cd $builddir
@@ -116,13 +194,32 @@ cmake .. \
 	-DENABLE_FREETYPE=1 \
 	-DENABLE_LEVELDB=1 \
 	\
+	-DUSE_STATIC_BUILD=1 \
+	-DUSE_SDL=1 \
+	-DSDL2_LIBRARIES="$libdir/SDL2/lib/libSDL2.a" \
+	-DSDL2_INCLUDE_DIRS="$libdir/SDL2/include/SDL2" \
+	\
+	-DCMAKE_C_FLAGS=" \
+		-DNO_IRR_COMPILE_WITH_SDL_TEXTINPUT_ \
+		-DNO_IRR_COMPILE_WITH_OGLES2_ \
+		-DNO_IRR_COMPILE_WITH_DIRECT3D_9_ \
+		-D_IRR_STATIC_LIB_" \
+	-DCMAKE_CXX_FLAGS=" \
+		-DNO_IRR_COMPILE_WITH_SDL_TEXTINPUT_ \
+		-DNO_IRR_COMPILE_WITH_OGLES2_ \
+		-DNO_IRR_COMPILE_WITH_DIRECT3D_9_ \
+		-D_IRR_STATIC_LIB_" \
 	-DIRRLICHT_INCLUDE_DIR=$libdir/irrlicht/include \
-	-DIRRLICHT_LIBRARY=$libdir/irrlicht/lib/Win32-gcc/libIrrlicht.dll.a \
-	-DIRRLICHT_DLL=$libdir/irrlicht/bin/Win32-gcc/Irrlicht.dll \
+	-DIRRLICHT_LIBRARY=$libdir/irrlicht/lib/Win32-gcc/libIrrlicht.a \
 	\
 	-DZLIB_INCLUDE_DIR=$libdir/zlib/include \
-	-DZLIB_LIBRARIES=$libdir/zlib/lib/libz.dll.a \
-	-DZLIB_DLL=$libdir/zlib/bin/zlib1.dll \
+	-DZLIB_LIBRARIES=$libdir/zlib/lib/libz.a \
+	\
+	-DPNG_INCLUDE_DIR="$libdir/libpng/include" \
+	-DPNG_LIBRARIES="$libdir/libpng/build/libpng16.a" \
+	\
+	-DJPEG_INCLUDE_DIR="$libdir/libjpeg/include" \
+	-DJPEG_LIBRARIES="$libdir/libjpeg/build/libjpeg.a" \
 	\
 	-DLUA_INCLUDE_DIR=$libdir/luajit/include \
 	-DLUA_LIBRARY=$libdir/luajit/libluajit.a \

--- a/util/buildbot/buildwin64.sh
+++ b/util/buildbot/buildwin64.sh
@@ -31,8 +31,8 @@ luajit_version=20230221
 leveldb_version=1.23
 zlib_version=1.2.13
 sdl_version=2.28.5
-jpeg_version=3.0.0
-png_version=1.6.40
+jpeg_version=3.0.1
+png_version=1.6.42
 
 mkdir -p $packagedir
 mkdir -p $libdir
@@ -97,9 +97,9 @@ if [ ! -d libjpeg ]; then
 		-DCMAKE_BUILD_TYPE=Release \
 		-DENABLE_SHARED=OFF \
 		-DCMAKE_C_FLAGS_RELEASE="$CFLAGS"
-	
+
 	cmake --build . -j$(nproc)
-	
+
 	cd -
 fi
 
@@ -111,7 +111,7 @@ if [ ! -d libpng ]; then
 	rm libpng-$png_version.tar.gz
 	mkdir libpng/build
 	cd libpng/build
-	
+
 	cmake .. \
 		-DCMAKE_TOOLCHAIN_FILE=$toolchain_file \
 		-DCMAKE_BUILD_TYPE=Release \
@@ -121,16 +121,16 @@ if [ ! -d libpng ]; then
 		-DPNG_BUILD_ZLIB=ON \
 		-DZLIB_INCLUDE_DIRS="$libdir/zlib/include" \
 		-DCMAKE_C_FLAGS_RELEASE="$CFLAGS"
-	
+
 	cmake --build . -j$(nproc)
-	
+
 	cd -
 fi
 
 # Get irrlicht
 if [ ! -d irrlicht ]; then
 	git clone --depth 1 -b SDL2 https://github.com/MoNTE48/Irrlicht irrlicht
-	
+
 	cd irrlicht/source/Irrlicht
 
 	CC="x86_64-w64-mingw32-gcc" \
@@ -149,7 +149,7 @@ if [ ! -d irrlicht ]; then
 		-I$libdir/libpng/build" \
 	CXXFLAGS="$CXXFLAGS -std=gnu++17" \
 	make staticlib_win32 -j$(nproc) NDEBUG=1
-	
+
 	cd -
 fi
 

--- a/util/buildbot/buildwin64.sh
+++ b/util/buildbot/buildwin64.sh
@@ -32,7 +32,7 @@ leveldb_version=1.23
 zlib_version=1.2.13
 sdl_version=2.28.5
 jpeg_version=3.0.1
-png_version=1.6.42
+png_version=1.6.41
 
 mkdir -p $packagedir
 mkdir -p $libdir

--- a/util/buildbot/buildwin64.sh
+++ b/util/buildbot/buildwin64.sh
@@ -32,7 +32,7 @@ leveldb_version=1.23
 zlib_version=1.2.13
 sdl_version=2.28.5
 jpeg_version=3.0.1
-png_version=1.6.41
+png_version=1.6.42
 
 mkdir -p $packagedir
 mkdir -p $libdir
@@ -118,8 +118,9 @@ if [ ! -d libpng ]; then
 		-DPNG_SHARED=OFF \
 		-DPNG_TESTS=OFF \
 		-DPNG_EXECUTABLES=OFF \
-		-DPNG_BUILD_ZLIB=ON \
-		-DZLIB_INCLUDE_DIRS="$libdir/zlib/include" \
+		-DZLIB_ROOT="$libdir/zlib" \
+		-DZLIB_LIBRARY="$libdir/zlib/lib/libz.a" \
+		-DZLIB_INCLUDE_DIR="$libdir/zlib/include" \
 		-DCMAKE_C_FLAGS_RELEASE="$CFLAGS"
 
 	cmake --build . -j$(nproc)

--- a/util/ci/build.sh
+++ b/util/ci/build.sh
@@ -3,6 +3,8 @@
 mkdir cmakebuild
 cd cmakebuild
 cmake -DCMAKE_BUILD_TYPE=Debug \
+	-DUSE_SDL=ON \
+	-DIRRLICHT_SOURCE_DIR="../deps/Irrlicht" \
 	-DRUN_IN_PLACE=TRUE -DENABLE_GETTEXT=TRUE \
 	-DBUILD_UNITTESTS=TRUE \
 	-DBUILD_SERVER=TRUE ${CMAKE_FLAGS} ..

--- a/util/ci/clang-tidy.sh
+++ b/util/ci/clang-tidy.sh
@@ -3,6 +3,8 @@
 mkdir -p cmakebuild
 cd cmakebuild
 cmake -DCMAKE_BUILD_TYPE=Debug \
+	-DUSE_SDL=ON \
+	-DIRRLICHT_SOURCE_DIR="../deps/Irrlicht" \
 	-DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
 	-DRUN_IN_PLACE=TRUE \
 	-DENABLE_{GETTEXT,SOUND}=FALSE \

--- a/util/ci/common.sh
+++ b/util/ci/common.sh
@@ -2,7 +2,7 @@
 
 # Linux build only
 install_linux_deps() {
-	local pkgs=(libirrlicht-dev cmake libbz2-dev libpng-dev \
+	local pkgs=(cmake git libsdl2-dev libbz2-dev libpng-dev \
 		libjpeg-dev libxxf86vm-dev libgl1-mesa-dev libsqlite3-dev \
 		libhiredis-dev libogg-dev libgmp-dev libvorbis-dev libopenal-dev \
 		gettext libpq-dev libleveldb-dev libcurl4-openssl-dev)
@@ -21,4 +21,14 @@ install_macosx_deps() {
 		brew install jpeg
 	fi
 	#brew upgrade postgresql
+}
+
+# Build linux dependencies
+build_linux_deps() {
+	mkdir deps
+	cd deps
+	git clone --depth 1 -b SDL2 https://github.com/MoNTE48/Irrlicht
+	cd Irrlicht/source/Irrlicht
+	make -j
+	cd ../../../
 }


### PR DESCRIPTION
Vcpkg needs cmake build system for irrlicht, so for now it uses
    git clone --depth 1 -b cmake https://github.com/deveee/Irrlicht irrlicht
It should be changed later.
