### PR TITLE
Require "debug" priv to enable tooltip_append_itemname

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3124,6 +3124,10 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 		return;
 	}
 
+	// Update m_tooltip_append_itemname depending on debug privilege
+	m_tooltip_append_itemname = m_client->checkPrivilege("debug") ?
+		g_settings->getBool("tooltip_append_itemname") : false;
+
 	parserData mydata;
 
 	// Preserve stuff only on same form, not on a new form.

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3125,8 +3125,10 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	}
 
 	// Update m_tooltip_append_itemname depending on debug privilege
-	m_tooltip_append_itemname = m_client->checkPrivilege("debug") ?
-		g_settings->getBool("tooltip_append_itemname") : false;
+	if (m_client != nullptr) {
+		m_tooltip_append_itemname = m_client->checkPrivilege("debug") ?
+			g_settings->getBool("tooltip_append_itemname") : false;
+	}
 
 	parserData mydata;
 


### PR DESCRIPTION
Untested because I had trouble the last time I tried to compile MultiCraft on my laptop