### PR TITLE
Use main menu background for load screen

### DIFF
--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -184,8 +184,8 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 		g_menucloudsmgr = RenderingEngine::get_scene_manager()->createNewSceneManager();
 	if (!g_menuclouds)
 		g_menuclouds = new Clouds(g_menucloudsmgr, -1, rand());
-	g_menuclouds->setHeight(100.0f);
-	g_menuclouds->update(v3f(0, 0, 0), video::SColor(255, 240, 240, 255));
+//	g_menuclouds->setHeight(100.0f); // 120 is default value
+//	g_menuclouds->update(v3f(0, 0, 0), video::SColor(255, 240, 240, 255));
 	scene::ICameraSceneNode* camera;
 	camera = g_menucloudsmgr->addCameraSceneNode(NULL, v3f(0, 0, 0), v3f(0, 60, 100));
 	camera->setFarValue(10000);

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -796,8 +796,7 @@ protected:
 	// Misc
 	void limitFps(FpsControl *fps_timings, f32 *dtime);
 
-	void showOverlayMessage(const char *msg, float dtime, int percent,
-			bool draw_clouds = false);
+	void showOverlayMessage(const char *msg, float dtime, int percent);
 
 	static void settingChangedCallback(const std::string &setting_name, void *data);
 	void readSettings();
@@ -4234,11 +4233,10 @@ inline void Game::limitFps(FpsControl *fps_timings, f32 *dtime)
 #endif
 }
 
-void Game::showOverlayMessage(const char *msg, float dtime, int percent, bool draw_clouds)
+void Game::showOverlayMessage(const char *msg, float dtime, int percent)
 {
 	const wchar_t *wmsg = wgettext(msg);
-	RenderingEngine::draw_load_screen(wmsg, guienv, texture_src, dtime, percent,
-		draw_clouds);
+	RenderingEngine::draw_load_screen(wmsg, guienv, texture_src, dtime, percent);
 	delete[] wmsg;
 }
 

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -630,7 +630,7 @@ void RenderingEngine::_draw_menu_scene(gui::IGUIEnvironment *guienv,
 void RenderingEngine::_draw_load_bg(gui::IGUIEnvironment *guienv,
 									ITextureSource *tsrc, float dtime)
 {
-	driver->beginScene(true, true, video::SColor(255, 140, 186, 250));
+	driver->beginScene(true, true, video::SColor(255, 5, 155, 245));
 
 	const bool cloud_menu_background = m_load_bg_clouds && g_settings->getBool("menu_clouds");
 	if (cloud_menu_background) {
@@ -666,7 +666,6 @@ void RenderingEngine::_draw_load_bg(gui::IGUIEnvironment *guienv,
 			core::rect<s32>(sourceX, sourceY, sourcesize.X - sourceX, sourcesize.Y - sourceY),
 			NULL, NULL, true);
 }
-
 
 std::vector<core::vector3d<u32>> RenderingEngine::getSupportedVideoModes()
 {

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -630,15 +630,13 @@ void RenderingEngine::_draw_menu_scene(gui::IGUIEnvironment *guienv,
 void RenderingEngine::_draw_load_bg(gui::IGUIEnvironment *guienv,
 									ITextureSource *tsrc, float dtime)
 {
+	driver->beginScene(true, true, video::SColor(255, 140, 186, 250));
+
 	const bool cloud_menu_background = m_load_bg_clouds && g_settings->getBool("menu_clouds");
 	if (cloud_menu_background) {
 		g_menuclouds->step(dtime * 3);
 		g_menuclouds->render();
-		driver->beginScene(
-				true, true, video::SColor(255, 140, 186, 250));
 		g_menucloudsmgr->drawAll();
-	} else {
-		driver->beginScene(true, true, video::SColor(255, 0, 0, 0));
 	}
 
 	const v2u32 screensize = driver->getScreenSize();

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -637,13 +637,14 @@ void RenderingEngine::_draw_load_bg(gui::IGUIEnvironment *guienv,
 		driver->beginScene(
 				true, true, video::SColor(255, 140, 186, 250));
 		g_menucloudsmgr->drawAll();
+	} else {
+		driver->beginScene(true, true, video::SColor(255, 0, 0, 0));
 	}
 
 	const v2u32 screensize = driver->getScreenSize();
 	video::ITexture *texture = m_load_bg_texture.empty() ? nullptr : driver->getTexture(m_load_bg_texture.c_str());
 	if (texture == nullptr) {
 		if (!cloud_menu_background) {
-			driver->beginScene(true, true, video::SColor(255, 0, 0, 0));
 			video::ITexture *background_image = tsrc->getTexture("bg.png");
 
 			driver->draw2DImage(background_image,

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -106,17 +106,17 @@ public:
 
 	inline static void draw_load_screen(const std::wstring &text,
 			gui::IGUIEnvironment *guienv, ITextureSource *tsrc,
-			float dtime = 0, int percent = 0, bool clouds = false)
+			float dtime = 0, int percent = 0)
 	{
 		s_singleton->_draw_load_screen(
-				text, guienv, tsrc, dtime, percent, clouds);
+				text, guienv, tsrc, dtime, percent);
 	}
 
 	inline static void draw_menu_scene(
 			gui::IGUIEnvironment *guienv, ITextureSource *tsrc,
-			float dtime, bool clouds = false)
+			float dtime)
 	{
-		s_singleton->_draw_menu_scene(guienv, tsrc, dtime, clouds);
+		s_singleton->_draw_menu_scene(guienv, tsrc, dtime);
 	}
 
 	inline static void draw_scene(video::SColor skycolor, bool show_hud,
@@ -142,14 +142,23 @@ public:
 	static std::vector<core::vector3d<u32>> getSupportedVideoModes();
 	static std::vector<irr::video::E_DRIVER_TYPE> getSupportedVideoDrivers();
 
+	static void setLoadScreenBackground(const bool clouds, const std::string texture)
+	{
+		if (s_singleton) {
+			s_singleton->m_load_bg_clouds = clouds;
+			s_singleton->m_load_bg_texture = texture;
+		}
+	}
+
 private:
 	void _draw_load_screen(const std::wstring &text, gui::IGUIEnvironment *guienv,
-			ITextureSource *tsrc, float dtime = 0, int percent = 0,
-			bool clouds = false);
+			ITextureSource *tsrc, float dtime = 0, int percent = 0);
 
 	void _draw_menu_scene(gui::IGUIEnvironment *guienv,
-			ITextureSource *tsrc, float dtime = 0,
-			bool clouds = false);
+			ITextureSource *tsrc, float dtime = 0);
+
+	void _draw_load_bg(gui::IGUIEnvironment *guienv,
+			ITextureSource *tsrc, float dtime = 0);
 
 	void _draw_scene(video::SColor skycolor, bool show_hud, bool show_minimap,
 			bool draw_wield_tool, bool draw_crosshair);
@@ -162,4 +171,7 @@ private:
 	irr::IrrlichtDevice *m_device = nullptr;
 	irr::video::IVideoDriver *driver;
 	static RenderingEngine *s_singleton;
+
+	bool m_load_bg_clouds = false;
+	std::string m_load_bg_texture = "";
 };

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -136,7 +136,7 @@ GUIEngine::GUIEngine(JoystickController *joystick,
 		bool &kill) :
 	m_parent(parent),
 	m_menumanager(menumgr),
-	m_smgr(RenderingEngine::get_scene_manager()),
+	m_smgr(g_menucloudsmgr),
 	m_data(data),
 	m_kill(kill)
 {
@@ -380,14 +380,15 @@ GUIEngine::~GUIEngine()
 
 	delete m_texture_source;
 
-	if (m_cloud.clouds)
-		m_cloud.clouds->drop();
+	// m_cloud.clouds is g_menuclouds and is dropped elsewhere
+	// if (m_cloud.clouds)
+	// 	m_cloud.clouds->drop();
 }
 
 /******************************************************************************/
 void GUIEngine::cloudInit()
 {
-	m_cloud.clouds = new Clouds(m_smgr, -1, rand());
+	m_cloud.clouds = g_menuclouds;
 	m_cloud.clouds->setHeight(100.0f);
 	m_cloud.clouds->update(v3f(0, 0, 0), video::SColor(255,240,240,255));
 

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -277,7 +277,7 @@ void GUIEngine::run()
 	irr::core::dimension2d<u32> previous_screen_size(g_settings->getU16("screen_w"),
 		g_settings->getU16("screen_h"));
 
-	static const video::SColor sky_color(255, 140, 186, 250);
+	static const video::SColor sky_color(255, 5, 155, 245);
 
 	// Reset fog color
 	{
@@ -389,8 +389,8 @@ GUIEngine::~GUIEngine()
 void GUIEngine::cloudInit()
 {
 	m_cloud.clouds = g_menuclouds;
-	m_cloud.clouds->setHeight(100.0f);
-	m_cloud.clouds->update(v3f(0, 0, 0), video::SColor(255,240,240,255));
+//	m_cloud.clouds->setHeight(100.0f); // 120 is default value
+//	m_cloud.clouds->update(v3f(0, 0, 0), video::SColor(255,240,240,255));
 
 	m_cloud.camera = m_smgr->addCameraSceneNode(0,
 				v3f(0,0,0), v3f(0, 60, 100));

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -214,6 +214,12 @@ GUIEngine::GUIEngine(JoystickController *joystick,
 		handleMainMenuLuaError(e.what());
 	}
 
+	// Update the load screen background texture
+	const texture_layer layer = m_clouds_enabled ? TEX_LAYER_OVERLAY : TEX_LAYER_BACKGROUND;
+	const video::ITexture* texture = m_textures[layer].texture;
+	RenderingEngine::setLoadScreenBackground(m_clouds_enabled,
+			(texture && !m_textures[layer].tile) ? texture->getName().getPath().c_str() : "");
+
 	m_menu->quitMenu();
 	m_menu->drop();
 	m_menu = NULL;


### PR DESCRIPTION
This doesn't support tiled background textures for simplicity (any games using them will just fall back to the dirt background on the loading screen), I can add support if you want but I'm not sure if any games use tiled background textures.