### PR TITLE
Centre multi-line button labels

### DIFF
--- a/src/gui/guiButton.cpp
+++ b/src/gui/guiButton.cpp
@@ -49,6 +49,10 @@ GUIButton::GUIButton(IGUIEnvironment* environment, IGUIElement* parent,
 	}
 	StaticText = gui::StaticText::add(Environment, Text.c_str(), core::rect<s32>(0,0,rectangle.getWidth(),rectangle.getHeight()), false, false, this, id);
 	StaticText->setTextAlignment(EGUIA_CENTER, EGUIA_CENTER);
+	if (StaticText->hasType(irr::gui::EGUIET_ENRICHED_STATIC_TEXT)) {
+		irr::gui::StaticText* stext = static_cast<irr::gui::StaticText*>(StaticText);
+		stext->setCenterEachLine(true);
+	}
 	// END PATCH
 }
 

--- a/src/irrlicht_changes/static_text.cpp
+++ b/src/irrlicht_changes/static_text.cpp
@@ -11,6 +11,7 @@
 #include <IVideoDriver.h>
 #include <rect.h>
 #include <SColor.h>
+#include <iostream>
 
 #if USE_FREETYPE
 	#include "CGUITTFont.h"
@@ -86,8 +87,11 @@ void StaticText::draw()
 		core::rect<s32> r = frameRect;
 		s32 height_line = font->getDimension(L"A").Height + font->getKerningHeight();
 		s32 height_total = height_line * BrokenText.size();
-		if (VAlign == EGUIA_CENTER && WordWrap)
+		if (VAlign == EGUIA_CENTER)
 		{
+			// Calculate the line height in the exact same way that it used to be
+			height_total = font->getDimension(ColoredText.c_str()).Height;
+			height_line -= 1; // Remove the 1px offset added by getDimension
 			r.UpperLeftCorner.Y = r.getCenter().Y - (height_total / 2);
 		}
 		else if (VAlign == EGUIA_LOWERRIGHT)
@@ -112,7 +116,7 @@ void StaticText::draw()
 			if (font->getType() == irr::gui::EGFT_CUSTOM) {
 				irr::gui::CGUITTFont *tmp = static_cast<irr::gui::CGUITTFont*>(font);
 				tmp->draw(str,
-					r, HAlign == EGUIA_CENTER, VAlign == EGUIA_CENTER,
+					r, HAlign == EGUIA_CENTER, false,
 					(RestrainTextInside ? &AbsoluteClippingRect : NULL));
 			} else
 #endif
@@ -120,7 +124,7 @@ void StaticText::draw()
 				// Draw non-colored text
 				font->draw(str.c_str(),
 					r, str.getDefaultColor(), // TODO: Implement colorization
-					HAlign == EGUIA_CENTER, VAlign == EGUIA_CENTER,
+					HAlign == EGUIA_CENTER, false,
 					(RestrainTextInside ? &AbsoluteClippingRect : NULL));
 			}
 
@@ -313,6 +317,14 @@ void StaticText::updateText()
 		setDrawBackground(false);
 
 	if (!WordWrap) {
+		if (VAlign == EGUIA_CENTER) {
+			size_t pos = 0;
+			while (pos < cText.size()) {
+				BrokenText.push_back(cText.getNextLine(&pos));
+			}
+			return;
+		}
+
 		BrokenText.push_back(cText);
 		return;
 	}

--- a/src/irrlicht_changes/static_text.cpp
+++ b/src/irrlicht_changes/static_text.cpp
@@ -34,7 +34,7 @@ StaticText::StaticText(const EnrichedString &text, bool border,
 : IGUIStaticText(environment, parent, id, rectangle),
 	HAlign(EGUIA_UPPERLEFT), VAlign(EGUIA_UPPERLEFT),
 	Border(border), WordWrap(false), Background(background),
-	RestrainTextInside(true), RightToLeft(false),
+	RestrainTextInside(true), RightToLeft(false), CenterEachLine(false),
 	OverrideFont(0), LastBreakFont(0)
 {
 	#ifdef _DEBUG
@@ -87,7 +87,7 @@ void StaticText::draw()
 		core::rect<s32> r = frameRect;
 		s32 height_line = font->getDimension(L"A").Height + font->getKerningHeight();
 		s32 height_total = height_line * BrokenText.size();
-		if (VAlign == EGUIA_CENTER)
+		if (VAlign == EGUIA_CENTER && (WordWrap || CenterEachLine))
 		{
 			// Calculate the line height in the exact same way that it used to be
 			height_total = font->getDimension(ColoredText.c_str()).Height;
@@ -116,7 +116,7 @@ void StaticText::draw()
 			if (font->getType() == irr::gui::EGFT_CUSTOM) {
 				irr::gui::CGUITTFont *tmp = static_cast<irr::gui::CGUITTFont*>(font);
 				tmp->draw(str,
-					r, HAlign == EGUIA_CENTER, false,
+					r, HAlign == EGUIA_CENTER, VAlign == EGUIA_CENTER && !CenterEachLine,
 					(RestrainTextInside ? &AbsoluteClippingRect : NULL));
 			} else
 #endif
@@ -124,7 +124,7 @@ void StaticText::draw()
 				// Draw non-colored text
 				font->draw(str.c_str(),
 					r, str.getDefaultColor(), // TODO: Implement colorization
-					HAlign == EGUIA_CENTER, false,
+					HAlign == EGUIA_CENTER, VAlign == EGUIA_CENTER && !CenterEachLine,
 					(RestrainTextInside ? &AbsoluteClippingRect : NULL));
 			}
 
@@ -245,6 +245,12 @@ void StaticText::setTextAlignment(EGUI_ALIGNMENT horizontal, EGUI_ALIGNMENT vert
 }
 
 
+void StaticText::setCenterEachLine(const bool centerEachLine)
+{
+	CenterEachLine = centerEachLine;
+}
+
+
 #if IRRLICHT_VERSION_MAJOR == 1 && IRRLICHT_VERSION_MINOR <= 7
 const video::SColor& StaticText::getOverrideColor() const
 #else
@@ -317,7 +323,7 @@ void StaticText::updateText()
 		setDrawBackground(false);
 
 	if (!WordWrap) {
-		if (VAlign == EGUIA_CENTER) {
+		if (VAlign == EGUIA_CENTER && CenterEachLine) {
 			size_t pos = 0;
 			while (pos < cText.size()) {
 				BrokenText.push_back(cText.getNextLine(&pos));

--- a/src/irrlicht_changes/static_text.h
+++ b/src/irrlicht_changes/static_text.h
@@ -201,6 +201,8 @@ namespace gui
 
 		void setText(const EnrichedString &text);
 
+		void setCenterEachLine(const bool centerEachLine);
+
 	private:
 
 		//! Breaks the single text line.
@@ -212,6 +214,7 @@ namespace gui
 		bool Background;
 		bool RestrainTextInside;
 		bool RightToLeft;
+		bool CenterEachLine;
 
 		gui::IGUIFont* OverrideFont;
 		gui::IGUIFont* LastBreakFont; // stored because: if skin changes, line break must be recalculated.

--- a/src/util/enriched_string.cpp
+++ b/src/util/enriched_string.cpp
@@ -165,6 +165,21 @@ void EnrichedString::operator+=(const EnrichedString &other)
 	}
 }
 
+EnrichedString EnrichedString::getNextLine(size_t *pos) const
+{
+	size_t str_pos = *pos;
+
+	// Split per line
+	size_t str_nl = getString().find(L'\n', str_pos);
+	if (str_nl == std::wstring::npos)
+		str_nl = getString().size();
+	EnrichedString line = substr(str_pos, str_nl - str_pos);
+	str_pos += line.size() + 1;
+
+	*pos = str_pos;
+	return line;
+}
+
 EnrichedString EnrichedString::substr(size_t pos, size_t len) const
 {
 	if (pos >= m_string.length())

--- a/src/util/enriched_string.h
+++ b/src/util/enriched_string.h
@@ -49,6 +49,7 @@ public:
 	// color. The color used will be the one from the last character.
 	void addCharNoColor(wchar_t c);
 
+	EnrichedString getNextLine(size_t *pos) const;
 	EnrichedString substr(size_t pos = 0, size_t len = std::string::npos) const;
 	EnrichedString operator+(const EnrichedString &other) const;
 	void operator+=(const EnrichedString &other);


### PR DESCRIPTION
This probably introduces bugs somewhere that I have not found.

`EnrichedString::getNextLine` is from upstream Minetest.