### PR TITLE
Remove "#" prefix from MOTD message

### DIFF
--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -67,7 +67,7 @@ core.register_on_joinplayer(function(player)
 	--	end
 		local motd = core.settings:get("motd")
 		if motd ~= "" then
-			core.chat_send_player(player_name, "# Server: " .. motd)
+			core.chat_send_player(player_name, "Server: " .. motd)
 		end
 	end
 	core.send_join_message(player_name)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a9bf9d5a-40d1-473a-bf4c-36b12c5434b1)

If you run `/status`, the "#" is still there for consistency with the version message. Were you wanting me to remove it there too?

![image](https://github.com/user-attachments/assets/7a5652a1-077e-4c78-9b7f-ed2ec5db54c6)