### PR TITLE
v7p: Don't generate bedrock if "mapgen_bedrock" not registered

### DIFF
--- a/src/mapgen/mapgen_v7p.cpp
+++ b/src/mapgen/mapgen_v7p.cpp
@@ -222,8 +222,8 @@ void MapgenV7P::makeChunk(BlockMakeData *data)
 
 	blockseed = getBlockSeed2(full_node_min, seed);
 
-	if (node_max.Y <= bedrock_level) {
-		// Only generate bedrock
+	if (node_max.Y <= bedrock_level && c_bedrock != CONTENT_IGNORE) {
+		// Only generate bedrock (if enabled)
 		generateBedrock();
 	} else {
 		// Generate base and mountain terrain
@@ -380,8 +380,8 @@ int MapgenV7P::generateTerrain()
 		for (s16 y = node_min.Y - 1; y <= node_max.Y + 1; y++) {
 			if (vm->m_data[vi].getContent() == CONTENT_IGNORE) {
 				if (y <= surface_y) {
-					if (y <= bedrock_level)
-						vm->m_data[vi] = n_bedrock; // Bedrock
+					if (y <= bedrock_level && c_bedrock != CONTENT_IGNORE)
+						vm->m_data[vi] = n_bedrock; // Bedrock (if enabled)
 					else
 						vm->m_data[vi] = n_stone; // Base and mountain terrain
 				} else if (y <= water_level) {


### PR DESCRIPTION
This ended up just placing CONTENT_IGNORE instead of bedrock anyway.

This PR does not fix existing maps, maybe an LBM could somehow? Though this would be a bit harder given that y=-64 is in the above mapblock (maybe it could just copy everything at y=-63 for an easy workaround).

Newly generated areas in existing maps will work, however.

## To do

This PR is Ready for Review.
<!-- ^ delete one -->

## How to test

<!-- Example code or instructions -->
1. Join a world in a game that doesn't register `mapgen_bedrock` (like minetest_game), bedrock should not be generated at -64
2. Join a game that does register bedrock, bedrock should be generated at around -64 (as it did before)