### PR TITLE
Don't generate textures when image clipped by scroll container

### DIFF
--- a/src/gui/guiAnimatedImage.cpp
+++ b/src/gui/guiAnimatedImage.cpp
@@ -9,24 +9,29 @@
 #include <vector>
 
 GUIAnimatedImage::GUIAnimatedImage(gui::IGUIEnvironment *env, gui::IGUIElement *parent,
-	s32 id, const core::rect<s32> &rectangle, ISimpleTextureSource *tsrc) :
+	s32 id, const core::rect<s32> &rectangle, ISimpleTextureSource *tsrc,
+	const bool cache_resize) :
 	gui::IGUIElement(gui::EGUIET_ELEMENT, env, parent, id, rectangle),
-	m_tsrc(tsrc)
+	m_tsrc(tsrc), m_cache_resize(cache_resize)
 {
 }
 
 void GUIAnimatedImage::draw()
 {
+	video::IVideoDriver *driver = Environment->getVideoDriver();
+
 	// Fill in m_texture when not clipped by a scroll container
 	if (m_texture == nullptr && m_tsrc != nullptr && !m_texture_name.empty()) {
 		m_texture = m_tsrc->getTexture(m_texture_name);
-		m_texture_name.clear();
+
+		if (m_cache_resize)
+			// TODO: Do I have to call ->grab or ->drop at some point?
+			m_texture = guiScalingImageButton(driver, m_texture,
+					AbsoluteRect.getWidth(), AbsoluteRect.getHeight());
 	}
 
 	if (m_texture == nullptr)
 		return;
-
-	video::IVideoDriver *driver = Environment->getVideoDriver();
 
 	core::dimension2d<u32> size = m_texture->getOriginalSize();
 

--- a/src/gui/guiAnimatedImage.cpp
+++ b/src/gui/guiAnimatedImage.cpp
@@ -9,13 +9,20 @@
 #include <vector>
 
 GUIAnimatedImage::GUIAnimatedImage(gui::IGUIEnvironment *env, gui::IGUIElement *parent,
-	s32 id, const core::rect<s32> &rectangle) :
-	gui::IGUIElement(gui::EGUIET_ELEMENT, env, parent, id, rectangle)
+	s32 id, const core::rect<s32> &rectangle, ISimpleTextureSource *tsrc) :
+	gui::IGUIElement(gui::EGUIET_ELEMENT, env, parent, id, rectangle),
+	m_tsrc(tsrc)
 {
 }
 
 void GUIAnimatedImage::draw()
 {
+	// Fill in m_texture when not clipped by a scroll container
+	if (m_texture == nullptr && m_tsrc != nullptr && !m_texture_name.empty()) {
+		m_texture = m_tsrc->getTexture(m_texture_name);
+		m_texture_name.clear();
+	}
+
 	if (m_texture == nullptr)
 		return;
 
@@ -36,8 +43,11 @@ void GUIAnimatedImage::draw()
 	if (m_middle.getArea() == 0) {
 		const video::SColor color(255, 255, 255, 255);
 		const video::SColor colors[] = {color, color, color, color};
-		draw2DImageFilterScaled(driver, m_texture, AbsoluteRect, rect, cliprect,
-			colors, true);
+
+		// Temporary fix for issue #12581 in 5.6.0.
+		// Use legacy image when not rendering 9-slice image because draw2DImage9Slice
+		// uses NNAA filter which causes visual artifacts when image uses alpha blending.
+		driver->draw2DImage(m_texture, AbsoluteRect, rect, cliprect, colors, true);
 	} else {
 		draw2DImage9Slice(driver, m_texture, AbsoluteRect, rect, m_middle, cliprect);
 	}

--- a/src/gui/guiAnimatedImage.h
+++ b/src/gui/guiAnimatedImage.h
@@ -9,14 +9,20 @@ class ISimpleTextureSource;
 class GUIAnimatedImage : public gui::IGUIElement {
 public:
 	GUIAnimatedImage(gui::IGUIEnvironment *env, gui::IGUIElement *parent,
-		s32 id, const core::rect<s32> &rectangle, ISimpleTextureSource *tsrc = nullptr);
+		s32 id, const core::rect<s32> &rectangle, ISimpleTextureSource *tsrc = nullptr,
+		const bool cache_resize = false);
 
 	virtual void draw() override;
 
 	void setTexture(video::ITexture *texture) { m_texture = texture; };
 	video::ITexture *getTexture() const { return m_texture; };
 
-	void setTextureName(const std::string &texture_name) { m_texture_name = texture_name; };
+	void setTextureName(const std::string &texture_name) {
+		if (texture_name != m_texture_name) {
+			m_texture_name = texture_name;
+			m_texture = nullptr;
+		}
+	};
 	const std::string &getTextureName() const { return m_texture_name; };
 
 	void setMiddleRect(const core::rect<s32> &middle) { m_middle = middle; };
@@ -35,6 +41,7 @@ private:
 	ISimpleTextureSource *m_tsrc;
 	video::ITexture *m_texture = nullptr;
 	std::string m_texture_name = "";
+	bool m_cache_resize;
 
 	u64 m_global_time = 0;
 	s32 m_frame_idx = 0;

--- a/src/gui/guiAnimatedImage.h
+++ b/src/gui/guiAnimatedImage.h
@@ -9,12 +9,15 @@ class ISimpleTextureSource;
 class GUIAnimatedImage : public gui::IGUIElement {
 public:
 	GUIAnimatedImage(gui::IGUIEnvironment *env, gui::IGUIElement *parent,
-		s32 id, const core::rect<s32> &rectangle);
+		s32 id, const core::rect<s32> &rectangle, ISimpleTextureSource *tsrc = nullptr);
 
 	virtual void draw() override;
 
 	void setTexture(video::ITexture *texture) { m_texture = texture; };
 	video::ITexture *getTexture() const { return m_texture; };
+
+	void setTextureName(const std::string &texture_name) { m_texture_name = texture_name; };
+	const std::string &getTextureName() const { return m_texture_name; };
 
 	void setMiddleRect(const core::rect<s32> &middle) { m_middle = middle; };
 	core::rect<s32> getMiddleRect() const { return m_middle; };
@@ -29,7 +32,9 @@ public:
 	s32 getFrameIndex() const { return m_frame_idx; };
 
 private:
+	ISimpleTextureSource *m_tsrc;
 	video::ITexture *m_texture = nullptr;
+	std::string m_texture_name = "";
 
 	u64 m_global_time = 0;
 	s32 m_frame_idx = 0;

--- a/src/gui/guiAnimatedImage.h
+++ b/src/gui/guiAnimatedImage.h
@@ -10,7 +10,7 @@ class GUIAnimatedImage : public gui::IGUIElement {
 public:
 	GUIAnimatedImage(gui::IGUIEnvironment *env, gui::IGUIElement *parent,
 		s32 id, const core::rect<s32> &rectangle, ISimpleTextureSource *tsrc = nullptr,
-		const bool cache_resize = false);
+		const bool use_scaling_filter = false);
 
 	virtual void draw() override;
 
@@ -41,7 +41,7 @@ private:
 	ISimpleTextureSource *m_tsrc;
 	video::ITexture *m_texture = nullptr;
 	std::string m_texture_name = "";
-	bool m_cache_resize;
+	bool m_use_scaling_filter;
 
 	u64 m_global_time = 0;
 	s32 m_frame_idx = 0;

--- a/src/gui/guiButtonImage.cpp
+++ b/src/gui/guiButtonImage.cpp
@@ -35,7 +35,7 @@ GUIButtonImage::GUIButtonImage(gui::IGUIEnvironment *environment,
 	: GUIButton(environment, parent, id, rectangle, tsrc, noclip)
 {
 	GUIButton::setScaleImage(true);
-	m_image = make_irr<GUIAnimatedImage>(environment, this, id, rectangle);
+	m_image = make_irr<GUIAnimatedImage>(environment, this, id, rectangle, tsrc, true);
 	sendToBack(m_image.get());
 }
 
@@ -58,12 +58,12 @@ void GUIButtonImage::setFromStyle(const StyleSpec &style)
 	video::IVideoDriver *driver = Environment->getVideoDriver();
 
 	if (style.isNotDefault(StyleSpec::FGIMG)) {
-		video::ITexture *texture = style.getTexture(StyleSpec::FGIMG,
-				getTextureSource());
+		const std::string texture_name = style.get(StyleSpec::FGIMG, "");
 
-		setForegroundImage(::grab(guiScalingImageButton(driver, texture,
-				AbsoluteRect.getWidth(), AbsoluteRect.getHeight())),
-				style.getRect(StyleSpec::FGIMG_MIDDLE, m_image->getMiddleRect()));
+		// Use setTextureName instead of setForegroundImage
+		m_foreground_image = nullptr;
+		m_image->setTextureName(texture_name);
+		m_image->setMiddleRect(style.getRect(StyleSpec::FGIMG_MIDDLE, m_image->getMiddleRect()));
 	} else {
 		setForegroundImage();
 	}

--- a/src/gui/guiButtonImage.cpp
+++ b/src/gui/guiButtonImage.cpp
@@ -55,8 +55,6 @@ void GUIButtonImage::setFromStyle(const StyleSpec &style)
 {
 	GUIButton::setFromStyle(style);
 
-	video::IVideoDriver *driver = Environment->getVideoDriver();
-
 	if (style.isNotDefault(StyleSpec::FGIMG)) {
 		const std::string texture_name = style.get(StyleSpec::FGIMG, "");
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -846,12 +846,12 @@ void GUIFormSpecMenu::parseImage(parserData* data, const std::string &element)
 		}
 
 		std::string name = unescape_string(parts[1 + offset]);
-		video::ITexture *texture = m_tsrc->getTexture(name);
 
 		v2s32 pos;
 		v2s32 geom;
 
 		if (parts.size() < 3) {
+			video::ITexture *texture = m_tsrc->getTexture(name);
 			if (texture != nullptr) {
 				core::dimension2du dim = texture->getOriginalSize();
 				geom.X = dim.Width;
@@ -890,26 +890,11 @@ void GUIFormSpecMenu::parseImage(parserData* data, const std::string &element)
 		if (parts.size() >= 4)
 			parseMiddleRect(parts[3], &middle);
 
-		// Temporary fix for issue #12581 in 5.6.0.
-		// Use legacy image when not rendering 9-slice image because GUIAnimatedImage
-		// uses NNAA filter which causes visual artifacts when image uses alpha blending.
+		GUIAnimatedImage *e = new GUIAnimatedImage(Environment, data->current_parent,
+			spec.fid, rect, m_tsrc);
 
-		gui::IGUIElement *e;
-		if (middle.getArea() > 0) {
-			GUIAnimatedImage *image = new GUIAnimatedImage(Environment, data->current_parent,
-				spec.fid, rect);
-
-			image->setTexture(texture);
-			image->setMiddleRect(middle);
-			e = image;
-		}
-		else {
-			gui::IGUIImage *image = Environment->addImage(rect, data->current_parent, spec.fid, nullptr, true);
-			image->setImage(texture);
-			image->setScaleImage(true);
-			image->grab(); // compensate for drop in addImage
-			e = image;
-		}
+		e->setTextureName(name);
+		e->setMiddleRect(middle);
 
 		auto style = getDefaultStyleForElement("image", spec.fname);
 		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, m_formspec_version < 3));
@@ -976,9 +961,9 @@ void GUIFormSpecMenu::parseAnimatedImage(parserData *data, const std::string &el
 		parseMiddleRect(parts[7], &middle);
 
 	GUIAnimatedImage *e = new GUIAnimatedImage(Environment, data->current_parent,
-		spec.fid, rect);
+		spec.fid, rect, m_tsrc);
 
-	e->setTexture(m_tsrc->getTexture(texture_name));
+	e->setTextureName(texture_name);
 	e->setMiddleRect(middle);
 	e->setFrameDuration(frame_duration);
 	e->setFrameCount(frame_count);


### PR DESCRIPTION
This only changes `image[]`, `animated_image[]`, and `image_button[]` (excluding the `bgimg` style).