### PR TITLE
Use alpha test for transparent materials that don't use alpha blending.

### DIFF
--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -73,6 +73,12 @@ void main(void)
 	}
 #endif
 
+#ifdef USE_ALPHA_TEST_DISCARD
+	if (base.a < 0.5) {
+		discard;
+	}
+#endif
+
 	color = base.rgb;
 
 	vec4 col = vec4(color.rgb * varColor.rgb, 1.0);

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -71,6 +71,12 @@ void main(void)
 	}
 #endif
 
+#ifdef USE_ALPHA_TEST_DISCARD
+	if (base.a < 0.5) {
+		discard;
+	}
+#endif
+
 	color = base.rgb;
 
 	vec4 col = vec4(color.rgb, base.a);

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -603,8 +603,12 @@ ShaderInfo ShaderSource::generateShader(const std::string &name,
 			)";
 	}
 
-	if (use_gles && shaderinfo.base_material != video::EMT_SOLID)
-		shaders_header << "#define USE_DISCARD 1\n";
+	if (use_gles) {
+		if (shaderinfo.base_material == video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF)
+			shaders_header << "#define USE_ALPHA_TEST_DISCARD 1\n";
+		else if (shaderinfo.base_material != video::EMT_SOLID)
+			shaders_header << "#define USE_DISCARD 1\n";
+	}
 
 #define PROVIDE(constant) shaders_header << "#define " #constant " " << (int)constant << "\n"
 


### PR DESCRIPTION
It makes it working in the same way as for OpenGL renderer because GLES2 doesn't have GL_ALPHA_TEST and it needs to be done in shader.