### PR TITLE
core.get_natural_light(): Fix outside of map error

### DIFF
--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -419,8 +419,10 @@ int ModApiEnvMod::l_get_natural_light(lua_State *L)
 
 	bool is_position_ok;
 	MapNode n = env->getMap().getNode(pos, &is_position_ok);
-	if (!is_position_ok)
-		return 0;
+	if (!is_position_ok) {
+		lua_pushinteger(L, 0);
+		return 1;
+	}
 
 	// If the daylight is 0, nothing needs to be calculated
 	u8 daylight = n.param1 & 0x0f;

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -419,10 +419,8 @@ int ModApiEnvMod::l_get_natural_light(lua_State *L)
 
 	bool is_position_ok;
 	MapNode n = env->getMap().getNode(pos, &is_position_ok);
-	if (!is_position_ok) {
-		lua_pushinteger(L, 0);
-		return 1;
-	}
+	if (!is_position_ok)
+		return 0;
 
 	// If the daylight is 0, nothing needs to be calculated
 	u8 daylight = n.param1 & 0x0f;

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1118,6 +1118,13 @@ u8 ServerEnvironment::findSunlight(v3s16 pos) const
 
 		for (const v3s16& off : dirs) {
 			v3s16 neighborPos = currentPos + off;
+
+			// Do not walk nodes that are outside the map
+			if (abs(neighborPos.X) > MAX_MAP_GENERATION_LIMIT ||
+					abs(neighborPos.Y) > MAX_MAP_GENERATION_LIMIT ||
+					abs(neighborPos.Z) > MAX_MAP_GENERATION_LIMIT)
+				continue;
+
 			s64 neighborHash = MapDatabase::getBlockAsInteger(neighborPos);
 
 			// Do not walk neighborPos multiple times unless the distance to the start


### PR DESCRIPTION
I couldn't get it to crash with invalid positions, so I assume it returning `nil` instead of a number (as mods probably expect) is the problem. 