### PR TITLE
Backport interrupting synchronous HTTP fetches, add core.cancel_all_download_files()

### DIFF
--- a/doc/menu_lua_api.txt
+++ b/doc/menu_lua_api.txt
@@ -94,6 +94,8 @@ HTTP Requests
 * core.download_file(url, target) (possible in async calls)
     * url to download, and target to store to
     * returns true/false
+* core.cancel_all_download_files() (possible in async calls)
+    * Cancels all calls to core.download_file running in other threads
 * `minetest.get_http_api()` (possible in async calls)
     * returns `HTTPApiTable` containing http functions.
     * The returned table contains the functions `fetch_sync`, `fetch_async` and

--- a/src/convert_json.cpp
+++ b/src/convert_json.cpp
@@ -40,9 +40,9 @@ Json::Value fetchJsonValue(const std::string &url,
 	if (extra_headers != NULL)
 		fetch_request.extra_headers = *extra_headers;
 
-	httpfetch_sync(fetch_request, fetch_result);
+	bool completed = httpfetch_sync_interruptible(fetch_request, fetch_result);
 
-	if (!fetch_result.succeeded) {
+	if (!completed || !fetch_result.succeeded) {
 		return Json::Value();
 	}
 	Json::Value root;

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -591,13 +591,15 @@ bool GUIEngine::downloadFile(const std::string &url, const std::string &target)
 	fetch_request.url = url;
 	fetch_request.caller = HTTPFETCH_SYNC;
 	fetch_request.timeout = g_settings->getS32("curl_file_download_timeout");
-	httpfetch_sync(fetch_request, fetch_result);
+	bool completed = httpfetch_sync_interruptible(fetch_request, fetch_result);
 
-	if (!fetch_result.succeeded) {
+	if (!completed || !fetch_result.succeeded) {
 		target_file.close();
 		fs::DeleteSingleFileOrEmptyDirectory(target);
 		return false;
 	}
+	// TODO: directly stream the response data into the file instead of first
+	// storing the complete response in memory
 	target_file << fetch_result.data;
 
 	return true;

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -578,6 +578,9 @@ bool GUIEngine::setTexture(texture_layer layer, const std::string &texturepath,
 }
 
 /******************************************************************************/
+std::atomic<unsigned int> GUIEngine::s_download_file_reset_counter = {0};
+
+/******************************************************************************/
 bool GUIEngine::downloadFile(const std::string &url, const std::string &target)
 {
 #if USE_CURL
@@ -586,12 +589,17 @@ bool GUIEngine::downloadFile(const std::string &url, const std::string &target)
 		return false;
 	}
 
+	unsigned int counter = s_download_file_reset_counter.load();
+	auto is_cancelled = [&]() -> bool {
+		return s_download_file_reset_counter != counter;
+	};
+
 	HTTPFetchRequest fetch_request;
 	HTTPFetchResult fetch_result;
 	fetch_request.url = url;
 	fetch_request.caller = HTTPFETCH_SYNC;
 	fetch_request.timeout = g_settings->getS32("curl_file_download_timeout");
-	bool completed = httpfetch_sync_interruptible(fetch_request, fetch_result);
+	bool completed = httpfetch_sync_interruptible(fetch_request, fetch_result, 100, is_cancelled);
 
 	if (!completed || !fetch_result.succeeded) {
 		target_file.close();

--- a/src/gui/guiEngine.h
+++ b/src/gui/guiEngine.h
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 /******************************************************************************/
 /* Includes                                                                   */
 /******************************************************************************/
+#include <atomic>
 #include "irrlichttypes.h"
 #include "guiFormSpecMenu.h"
 #include "client/sound.h"
@@ -224,12 +225,20 @@ private:
 	bool setTexture(texture_layer layer, const std::string &texturepath,
 			bool tile_image, unsigned int minsize);
 
+	/** used to check the validity of download_file requests */
+	static std::atomic<unsigned int> s_download_file_reset_counter;
+
 	/**
 	 * download a file using curl
 	 * @param url url to download
 	 * @param target file to store to
 	 */
 	static bool downloadFile(const std::string &url, const std::string &target);
+
+	static void cancelAllDownloadFiles()
+	{
+		s_download_file_reset_counter++;
+	}
 
 	/** array containing pointers to current specified texture layers */
 	image_definition m_textures[TEX_LAYER_MAX];

--- a/src/httpfetch.cpp
+++ b/src/httpfetch.cpp
@@ -798,14 +798,14 @@ static void httpfetch_sync(const HTTPFetchRequest &fetch_request,
 }
 
 bool httpfetch_sync_interruptible(const HTTPFetchRequest &fetch_request,
-		HTTPFetchResult &fetch_result, long interval)
+		HTTPFetchResult &fetch_result, long interval, std::function<bool()> is_cancelled)
 {
 	if (Thread *thread = Thread::getCurrentThread()) {
 		HTTPFetchRequest req = fetch_request;
 		req.caller = httpfetch_caller_alloc_secure();
 		httpfetch_async(req);
 		do {
-			if (thread->stopRequested()) {
+			if (thread->stopRequested() || (is_cancelled && is_cancelled())) {
 				httpfetch_caller_free(req.caller);
 				fetch_result = HTTPFetchResult(fetch_request);
 				return false;

--- a/src/httpfetch.cpp
+++ b/src/httpfetch.cpp
@@ -31,6 +31,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "exceptions.h"
 #include "debug.h"
 #include "log.h"
+#include "porting.h"
 #include "util/container.h"
 #include "util/thread.h"
 #include "version.h"
@@ -783,7 +784,7 @@ static void httpfetch_request_clear(unsigned long caller)
 	}
 }
 
-void httpfetch_sync(const HTTPFetchRequest &fetch_request,
+static void httpfetch_sync(const HTTPFetchRequest &fetch_request,
 		HTTPFetchResult &fetch_result)
 {
 	// Create ongoing fetch data and make a cURL handle
@@ -794,6 +795,28 @@ void httpfetch_sync(const HTTPFetchRequest &fetch_request,
 	CURLcode res = ongoing.start(NULL);
 	// Update fetch result
 	fetch_result = *ongoing.complete(res);
+}
+
+bool httpfetch_sync_interruptible(const HTTPFetchRequest &fetch_request,
+		HTTPFetchResult &fetch_result, long interval)
+{
+	if (Thread *thread = Thread::getCurrentThread()) {
+		HTTPFetchRequest req = fetch_request;
+		req.caller = httpfetch_caller_alloc_secure();
+		httpfetch_async(req);
+		do {
+			if (thread->stopRequested()) {
+				httpfetch_caller_free(req.caller);
+				fetch_result = HTTPFetchResult(fetch_request);
+				return false;
+			}
+			sleep_ms(interval);
+		} while (!httpfetch_async_get(req.caller, fetch_result));
+		httpfetch_caller_free(req.caller);
+	} else {
+		httpfetch_sync(fetch_request, fetch_result);
+	}
+	return true;
 }
 
 #else  // USE_CURL
@@ -825,13 +848,14 @@ static void httpfetch_request_clear(unsigned long caller)
 {
 }
 
-void httpfetch_sync(const HTTPFetchRequest &fetch_request,
-		HTTPFetchResult &fetch_result)
+bool httpfetch_sync_interruptible(const HTTPFetchRequest &fetch_request,
+		HTTPFetchResult &fetch_result, long interval)
 {
-	errorstream << "httpfetch_sync: unable to fetch " << fetch_request.url
+	errorstream << "httpfetch_sync_interruptible: unable to fetch " << fetch_request.url
 			<< " because USE_CURL=0" << std::endl;
 
 	fetch_result = HTTPFetchResult(fetch_request); // sets succeeded = false etc.
+	return false;
 }
 
 #endif  // USE_CURL

--- a/src/httpfetch.h
+++ b/src/httpfetch.h
@@ -126,4 +126,4 @@ void httpfetch_caller_free(unsigned long caller);
 // This blocks and therefore should only be used from background threads.
 // Returned is whether the request completed without interruption.
 bool httpfetch_sync_interruptible(const HTTPFetchRequest &fetch_request,
-		HTTPFetchResult &fetch_result, long interval = 100);
+		HTTPFetchResult &fetch_result, long interval = 25);

--- a/src/httpfetch.h
+++ b/src/httpfetch.h
@@ -121,6 +121,9 @@ unsigned long httpfetch_caller_alloc_secure();
 // to stop any ongoing fetches for the given caller.
 void httpfetch_caller_free(unsigned long caller);
 
-// Performs a synchronous HTTP request. This blocks and therefore should
-// only be used from background threads.
-void httpfetch_sync(const HTTPFetchRequest &fetch_request, HTTPFetchResult &fetch_result);
+// Performs a synchronous HTTP request that is interruptible if the current
+// thread is a Thread object. interval is the completion check interval in ms.
+// This blocks and therefore should only be used from background threads.
+// Returned is whether the request completed without interruption.
+bool httpfetch_sync_interruptible(const HTTPFetchRequest &fetch_request,
+		HTTPFetchResult &fetch_result, long interval = 100);

--- a/src/httpfetch.h
+++ b/src/httpfetch.h
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include <functional>
 #include <vector>
 #include "util/string.h"
 #include "config.h"
@@ -126,4 +127,5 @@ void httpfetch_caller_free(unsigned long caller);
 // This blocks and therefore should only be used from background threads.
 // Returned is whether the request completed without interruption.
 bool httpfetch_sync_interruptible(const HTTPFetchRequest &fetch_request,
-		HTTPFetchResult &fetch_result, long interval = 25);
+		HTTPFetchResult &fetch_result, long interval = 25,
+		std::function<bool()> is_cancelled = {});

--- a/src/script/lua_api/l_http.cpp
+++ b/src/script/lua_api/l_http.cpp
@@ -117,9 +117,9 @@ int ModApiHttp::l_http_fetch_sync(lua_State *L)
 	infostream << "Mod performs HTTP request with URL " << req.url << std::endl;
 
 	HTTPFetchResult res;
-	httpfetch_sync(req, res);
+	bool completed = httpfetch_sync_interruptible(req, res);
 
-	push_http_fetch_result(L, res, true);
+	push_http_fetch_result(L, res, completed);
 
 	return 1;
 }

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -768,10 +768,17 @@ int ModApiMainMenu::l_download_file(lua_State *L)
 		}
 	} else {
 		errorstream << "DOWNLOAD denied: " << absolute_destination
-				<< " isn't a allowed path" << std::endl;
+		<< " isn't a allowed path" << std::endl;
 	}
 	lua_pushboolean(L,false);
 	return 1;
+}
+
+/******************************************************************************/
+int ModApiMainMenu::l_cancel_all_download_files(lua_State *L)
+{
+	GUIEngine::cancelAllDownloadFiles();
+	return 0;
 }
 
 /******************************************************************************/
@@ -940,6 +947,7 @@ void ModApiMainMenu::Initialize(lua_State *L, int top)
 	API_FCT(get_mainmenu_path);
 	API_FCT(show_path_select_dialog);
 	API_FCT(download_file);
+	API_FCT(cancel_all_download_files);
 	API_FCT(gettext);
 	API_FCT(get_video_drivers);
 	API_FCT(get_video_modes);
@@ -974,6 +982,7 @@ void ModApiMainMenu::InitializeAsync(lua_State *L, int top)
 	API_FCT(extract_zip);
 	API_FCT(may_modify_path);
 	API_FCT(download_file);
+	API_FCT(cancel_all_download_files);
 	API_FCT(get_min_supp_proto);
 	API_FCT(get_max_supp_proto);
 	//API_FCT(gettext); (gettext lib isn't threadsafe)

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -140,6 +140,8 @@ private:
 
 	static int l_download_file(lua_State *L);
 
+	static int l_cancel_all_download_files(lua_State *L);
+
 	static int l_get_video_drivers(lua_State *L);
 
 	static int l_get_video_modes(lua_State *L);

--- a/src/threading/sdl_thread.cpp
+++ b/src/threading/sdl_thread.cpp
@@ -31,6 +31,8 @@ DEALINGS IN THE SOFTWARE.
 
 #ifdef _IRR_COMPILE_WITH_SDL_DEVICE_
 
+thread_local Thread *current_thread = nullptr;
+
 Thread::Thread(const std::string &name) :
 		m_name(name), m_request_stop(false), m_running(false)
 {
@@ -108,6 +110,7 @@ bool Thread::getReturnValue(void **ret)
 int Thread::threadProc(void *data)
 {
 	Thread *thr = (Thread *)data;
+	current_thread = thr;
 
 	g_logger.registerThread(thr->m_name);
 	thr->m_running = true;
@@ -126,6 +129,11 @@ int Thread::threadProc(void *data)
 	g_logger.deregisterThread();
 
 	return 0;
+}
+
+Thread *Thread::getCurrentThread()
+{
+	return current_thread;
 }
 
 void Thread::setName(const std::string &name)

--- a/src/threading/sdl_thread.h
+++ b/src/threading/sdl_thread.h
@@ -99,6 +99,11 @@ public:
 	bool setPriority(SDL_ThreadPriority prio);
 
 	/*
+	 * Returns the thread object of the current thread if it exists.
+	 */
+	static Thread *getCurrentThread();
+
+	/*
 	 * Sets the currently executing thread's name to where supported; useful
 	 * for debugging.
 	 */

--- a/src/threading/thread.cpp
+++ b/src/threading/thread.cpp
@@ -62,6 +62,9 @@ DEALINGS IN THE SOFTWARE.
 #endif
 
 
+thread_local Thread *current_thread = nullptr;
+
+
 Thread::Thread(const std::string &name) :
 	m_name(name),
 	m_request_stop(false),
@@ -178,6 +181,8 @@ void Thread::threadProc(Thread *thr)
 	thr->m_kernel_thread_id = thread_self();
 #endif
 
+	current_thread = thr;
+
 	thr->setName(thr->m_name);
 
 	g_logger.registerThread(thr->m_name);
@@ -195,6 +200,12 @@ void Thread::threadProc(Thread *thr)
 	// released. We try to unlock it from caller thread and it's refused by system.
 	thr->m_start_finished_mutex.unlock();
 	g_logger.deregisterThread();
+}
+
+
+Thread *Thread::getCurrentThread()
+{
+	return current_thread;
 }
 
 

--- a/src/threading/thread.h
+++ b/src/threading/thread.h
@@ -124,6 +124,11 @@ public:
 	bool setPriority(int prio);
 
 	/*
+	 * Returns the thread object of the current thread if it exists.
+	 */
+	static Thread *getCurrentThread();
+
+	/*
 	 * Sets the currently executing thread's name to where supported; useful
 	 * for debugging.
 	 */


### PR DESCRIPTION
I'm not actually sure if cancelled requests get stopped, they seem to keep downloading in the background, but everything seems unaware of this