### PR TITLE
Block short passwords if the server doesn't allow empty passwords

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1130,7 +1130,7 @@ void Client::startAuth(AuthMechanism chosen_auth_mechanism)
 				&verifier, &salt);
 
 			NetworkPacket resp_pkt(TOSERVER_FIRST_SRP, 0);
-			resp_pkt << salt << verifier << (u8)((m_password.empty()) ? 1 : 0);
+			resp_pkt << salt << verifier << (u8)((m_password.size() < 3) ? 1 : 0);
 
 			Send(&resp_pkt);
 			break;


### PR DESCRIPTION
The "empty passwords are disallowed" message is displayed for 1 or 2 character passwords