### PR TITLE
Allow using secondary finger for place/dig actions.

### DIFF
--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -451,7 +451,7 @@ bool TouchScreenGUI::preprocessEvent(const SEvent &event)
 					m_camera.event_id = id;
 
 					updateCamera(m_camera, x, y);
-				} else if (m_camera_additional.event_id == -1) {
+				} else if (m_dig_and_move && m_camera_additional.event_id == -1) {
 					m_events[id] = true;
 					m_camera_additional.downtime = porting::getTimeMs();
 					m_camera_additional.x = x;
@@ -498,7 +498,7 @@ bool TouchScreenGUI::preprocessEvent(const SEvent &event)
 			}
 			m_camera.reset();
 			m_camera.place = place;
-		} else if (m_camera_additional.event_id == id) {
+		} else if (m_dig_and_move && m_camera_additional.event_id == id) {
 			bool place = false;
 			if (!m_camera_additional.has_really_moved && !m_camera_additional.dig) {
 				u64 delta = porting::getDeltaMs(m_camera_additional.downtime, porting::getTimeMs());
@@ -518,7 +518,7 @@ bool TouchScreenGUI::preprocessEvent(const SEvent &event)
 					result = true;
 			} else if (m_camera.event_id == id) {
 				updateCamera(m_camera, x, y);
-			} else if (m_camera_additional.event_id == id) {
+			} else if (m_dig_and_move && m_camera_additional.event_id == id) {
 				updateCamera(m_camera_additional, x, y);
 			} else {
 				bool overflow_btn_pressed = false;

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -128,6 +128,7 @@ struct camera_info
 	bool has_really_moved = false;
 	bool dig = false;
 	bool place = false;
+	bool place_shootline = false;
 	s32 x = 0;
 	s32 y = 0;
 	s32 event_id = -1;
@@ -138,6 +139,7 @@ struct camera_info
 		has_really_moved = false;
 		dig = false;
 		place = false;
+		place_shootline = false;
 		x = 0;
 		y = 0;
 		event_id = -1;
@@ -172,7 +174,16 @@ public:
 		return res;
 	}
 
-	line3d<f32> getShootline() { return m_camera.shootline; }
+	line3d<f32> getShootline()
+	{
+		if (m_camera_additional.event_id != -1 ||
+				m_camera_additional.place_shootline) {
+			m_camera_additional.place_shootline = false;
+			return m_camera_additional.shootline;
+		} else {
+			return m_camera.shootline;
+		}
+	}
 
 	void step(float dtime);
 	void hide();
@@ -204,6 +215,7 @@ private:
 	std::vector<button_info *> m_buttons;
 	joystick_info m_joystick;
 	camera_info m_camera;
+	camera_info m_camera_additional;
 
 	bool m_overflow_open = false;
 	bool m_overflow_close_schedule = false;
@@ -228,7 +240,7 @@ private:
 	void toggleOverflowMenu();
 
 	bool moveJoystick(s32 x, s32 y);
-	void updateCamera(s32 x, s32 y);
+	void updateCamera(camera_info &camera, s32 x, s32 y);
 
 	void setVisible(bool visible);
 


### PR DESCRIPTION
Also keep camera rotating after main finger is left up.

Works only when improved controls are enabled in settings.