### PR TITLE
 Add way to tell if client opens inventory 

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2205,6 +2205,13 @@ Elements
 * For information on converting forms to the new coordinate system, see `Migrating
   to Real Coordinates`.
 
+### `acknowledge_open[]`
+
+When used with the inventory formspec, the client will send an `"open"` field
+back to the server when the inventory is opened.
+
+Does not support formspecs other than the inventory.
+
 ### `container[<X>,<Y>]`
 
 * Start of a container block, moves all physical elements in the container by

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2212,7 +2212,14 @@ void Game::openInventory()
 	GUIFormSpecMenu::create(formspec, client, &input->joystick, fs_src,
 		txt_dst, client->getFormspecPrepend(), sound);
 
-	formspec->setFormSpec(fs_src->getForm(), inventoryloc);
+	const std::string form = fs_src->getForm();
+	formspec->setFormSpec(form, inventoryloc);
+
+	if (form.find("acknowledge_open[]") != std::string::npos) {
+		StringMap fields;
+		fields["open"] = "true";
+		txt_dst->gotText(fields);
+	}
 }
 
 


### PR DESCRIPTION
I wanted to make this opt in but that has led to it being a bit hacky (I tried integrating `acknowledge_open` into the actual formspec parsing code but that is less straightforward). Another option would be to add a new network packet type and just send it all the time when the inventory is opened.