### PR TITLE
Add `button_url` (without dialog)

### DIFF
--- a/Android/app/proguard-rules.pro
+++ b/Android/app/proguard-rules.pro
@@ -28,7 +28,7 @@
 	float getDensity();
 	void notifyServerConnect(boolean);
 	void notifyExitGame();
-	void openURI(java.lang.String);
+	boolean openURI(java.lang.String, boolean);
 	void finishGame(java.lang.String);
 	void handleError(java.lang.String);
 	boolean upgrade(java.lang.String);

--- a/Android/app/src/main/java/com/multicraft/game/GameActivity.kt
+++ b/Android/app/src/main/java/com/multicraft/game/GameActivity.kt
@@ -285,18 +285,20 @@ class GameActivity : SDLActivity() {
 	fun notifyExitGame() {
 	}
 
-	fun openURI(uri: String?) {
+	@Suppress("unused")
+	fun openURI(uri: String?, untrusted: Boolean): Boolean {
+		if (uri == null) return false
+
 		val builder = CustomTabsIntent.Builder()
 			.setShareState(SHARE_STATE_OFF)
 			.setShowTitle(true)
 			.setUrlBarHidingEnabled(true)
 			.setStartAnimations(this, R.anim.slide_in_bottom, R.anim.slide_out_top)
 			.setExitAnimations(this, R.anim.slide_in_top, R.anim.slide_out_bottom)
-		val customTabsIntent = builder.build()
-		try {
-			customTabsIntent.launchUrl(this, uri!!.toUri())
-		} catch (_: Exception) {
-		}
+			.build()
+		builder.launchUrl(this, uri.toUri())
+
+		return true
 	}
 
 	fun finishGame(exc: String?) {

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2477,6 +2477,16 @@ Does not support formspecs other than the inventory.
   centred on `H`. With the new coordinate system, `H` will modify the height.
 * `label` is the text on the button
 
+### `button_url[<X>,<Y>;<W>,<H>;<name>;<label>;<url>]`
+
+* Clickable button. When clicked, fields will be sent and the user will be given the
+  option to open the URL in a browser.
+* With the old coordinate system, buttons are a set height, but will be vertically
+  centered on `H`. With the new coordinate system, `H` will modify the height.
+* To make this into an `image_button`, you can use formspec styling.
+* `label` is the text on the button.
+* `url` must be a valid web URL, starting with `http://` or `https://`.
+
 ### `image_button[<X>,<Y>;<W>,<H>;<texture name>;<name>;<label>]`
 
 * `texture name` is the filename of an image
@@ -2501,6 +2511,11 @@ Does not support formspecs other than the inventory.
 
 * When clicked, fields will be sent and the form will quit.
 * Same as `button` in all other respects.
+
+### `button_url_exit[<X>,<Y>;<W>,<H>;<name>;<label>;<url>]`
+
+* When clicked, fields will be sent and the form will quit.
+* Same as `button_url` in all other respects.
 
 ### `image_button_exit[<X>,<Y>;<W>,<H>;<texture name>;<name>;<label>]`
 

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -121,6 +121,7 @@ class GUIFormSpecMenu : public GUIModalMenu
 		std::string fname;
 		std::wstring flabel;
 		std::wstring fdefault;
+		std::string url;
 		s32 fid;
 		bool send;
 		FormspecFieldType ftype;

--- a/src/gui/guiHyperText.cpp
+++ b/src/gui/guiHyperText.cpp
@@ -34,6 +34,8 @@ using namespace irr::gui;
 #include "hud.h"
 #include "guiHyperText.h"
 #include "util/string.h"
+#include "mainmenumanager.h"
+#include "porting.h"
 
 bool check_color(const std::string &str)
 {
@@ -1174,6 +1176,12 @@ bool GUIHyperText::OnEvent(const SEvent &event)
 							newEvent.GUIEvent.EventType = EGET_BUTTON_CLICKED;
 							Parent->OnEvent(newEvent);
 						}
+
+						auto url_it = tag->attrs.find("url");
+						if (url_it != tag->attrs.end()) {
+							porting::open_url(url_it->second, g_gamecallback != nullptr);
+						}
+
 						break;
 					}
 				}

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -719,12 +719,10 @@ static bool open_uri(const std::string &uri, bool untrusted = false)
 #if defined(_WIN32)
 	return (intptr_t)ShellExecuteA(NULL, NULL, uri.c_str(), NULL, NULL, SW_SHOWNORMAL) > 32;
 #elif defined(__ANDROID__)
-	openURIAndroid(uri);
-	return true;
+	return openURIAndroid(uri, untrusted);
 #elif defined(__APPLE__)
 #ifdef __IOS__
-	MultiCraft::openURL(uri.c_str());
-	return true;
+	return MultiCraft::openURI(uri.c_str(), untrusted);
 #else
 	const char *argv[] = {"open", uri.c_str(), NULL};
 	return posix_spawnp(NULL, "open", NULL, NULL, (char**)argv,

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -743,7 +743,7 @@ bool open_url(const std::string &url, bool untrusted)
 		return false;
 	}
 
-	return open_uri(url);
+	return open_uri(url, untrusted);
 }
 
 #if defined(__APPLE__)

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -709,7 +709,7 @@ int mt_snprintf(char *buf, const size_t buf_size, const char *fmt, ...)
 	return c;
 }
 
-static bool open_uri(const std::string &uri)
+static bool open_uri(const std::string &uri, bool untrusted = false)
 {
 	if (uri.find_first_of("\r\n") != std::string::npos) {
 		errorstream << "Unable to open URI as it is invalid, contains new line: " << uri << std::endl;
@@ -736,7 +736,7 @@ static bool open_uri(const std::string &uri)
 #endif
 }
 
-bool open_url(const std::string &url)
+bool open_url(const std::string &url, bool untrusted)
 {
 	if (url.substr(0, 7) != "http://" && url.substr(0, 8) != "https://") {
 		errorstream << "Unable to open browser as URL is missing schema: " << url << std::endl;

--- a/src/porting.h
+++ b/src/porting.h
@@ -344,7 +344,7 @@ int mt_snprintf(char *buf, const size_t buf_size, const char *fmt, ...);
  * @param url The URL
  * @return true on success, false on failure
  */
-bool open_url(const std::string &url);
+bool open_url(const std::string &url, bool untrusted = false);
 
 /**
  * Opens a directory in the default file manager

--- a/src/porting_android.cpp
+++ b/src/porting_android.cpp
@@ -169,17 +169,19 @@ void showInputDialog(const std::string &hint, const std::string &current, int ed
 	jnienv->DeleteLocalRef(jcurrent);
 }
 
-void openURIAndroid(const std::string &url)
+bool openURIAndroid(const std::string &url, bool untrusted)
 {
 	jmethodID url_open = jnienv->GetMethodID(activityClass, "openURI",
-		"(Ljava/lang/String;)V");
+		"(Ljava/lang/String;Z)Z");
 
 	FATAL_ERROR_IF(url_open == nullptr,
 		"porting::openURIAndroid unable to find Java openURI method");
 
 	jstring jurl = jnienv->NewStringUTF(url.c_str());
-	jnienv->CallVoidMethod(activityObj, url_open, jurl);
+	jboolean result = jnienv->CallBooleanMethod(activityObj, url_open, jurl, (jboolean) untrusted);
 	jnienv->DeleteLocalRef(jurl);
+
+	return result == JNI_TRUE;
 }
 
 std::string getInputDialogOwner()

--- a/src/porting_android.h
+++ b/src/porting_android.h
@@ -62,7 +62,7 @@ std::string getInputDialogOwner();
 
 bool isInputDialogActive();
 
-void openURIAndroid(const std::string &url);
+bool openURIAndroid(const std::string &url, bool untrusted);
 
 /**
  * get text in current input dialog


### PR DESCRIPTION
Backport of `button_url` but without the dialog, instead `untrusted` is passed to porting::open_url