### PR TITLE
Hypertext: Add "valign" to images

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -3084,7 +3084,7 @@ When clicked, the formspec is send to the server. The value of the text field
 sent to `on_player_receive_fields` will be "action:" concatenated to the action
 name.
 
-`<img name=... float=... width=... height=...>`
+`<img name=... float=... width=... height=... valign=...>`
 
 Draws an image which is present in the client media cache.
 
@@ -3092,10 +3092,12 @@ Draws an image which is present in the client media cache.
 * `float`: If present, makes the image floating (`left` or `right`).
 * `width`: Force image width instead of taking texture width.
 * `height`: Force image height instead of taking texture height.
+* `valign`: How to vertically align the image relative to the text next to it.
+Only effective if the image is smaller than the text. Defaults to "top".
 
 If only width or height given, texture aspect is kept.
 
-`<item name=... float=... width=... height=... rotate=...>`
+`<item name=... float=... width=... height=... rotate=... valign=...>`
 
 Draws an item image.
 
@@ -3109,6 +3111,8 @@ rotation speeds in percent of standard speed (-1000 to 1000). Works only if
 * `angle`: Angle in which the item image is shown. Value has `X,Y,Z` form.
 X, Y and Z being angles around each three axes. Works only if
 `inventory_items_animations` is set to true.
+* `valign`: How to vertically align the image relative to the text next to it.
+Only effective if the image is smaller than the text. Defaults to "top".
 
 Inventory
 =========

--- a/src/gui/guiHyperText.cpp
+++ b/src/gui/guiHyperText.cpp
@@ -549,6 +549,15 @@ u32 ParsedText::parseTag(const wchar_t *text, u32 cursor)
 			}
 		}
 
+		if (attrs.count("valign")) {
+			if (attrs["valign"] == "top")
+				m_element->valign = ParsedText::VALIGN_TOP;
+			else if (attrs["valign"] == "bottom")
+				m_element->valign = ParsedText::VALIGN_BOTTOM;
+			else if (attrs["valign"] == "middle")
+				m_element->valign = ParsedText::VALIGN_MIDDLE;
+		}
+
 		endElement();
 
 	} else if (name == "tag") {
@@ -880,6 +889,18 @@ void TextDrawer::place(const core::rect<s32> &dest_rect)
 				case ParsedText::ELEMENT_IMAGE:
 				case ParsedText::ELEMENT_ITEM:
 					x += e->dim.Width;
+
+					switch (e->valign) {
+					case ParsedText::VALIGN_BOTTOM:
+						e->pos.Y += charsheight - e->dim.Height;
+						break;
+					case ParsedText::VALIGN_MIDDLE:
+						e->pos.Y += (charsheight - e->dim.Height) / 2;
+						break;
+					case ParsedText::VALIGN_TOP:
+						// No action needed
+						break;
+					}
 					break;
 				}
 

--- a/src/gui/guiHyperText.h
+++ b/src/gui/guiHyperText.h
@@ -96,7 +96,7 @@ public:
 
 		FloatType floating = FLOAT_NONE;
 
-		ValignType valign;
+		ValignType valign = VALIGN_TOP;
 
 		gui::IGUIFont *font;
 


### PR DESCRIPTION
Only works when the image is smaller or the same size as the text and isn't perfect