### PR TITLE
Add support for experimental bulk media download

### DIFF
--- a/src/client/clientmedia.cpp
+++ b/src/client/clientmedia.cpp
@@ -513,7 +513,7 @@ void ClientMediaDownloader::startRemoteMediaTransfers()
 							break;
 					}
 
-					actionstream << "Client: "
+					verbosestream << "Client: "
 						<< "Requesting " << files.size()
 						<< " remote media files "
 						<< "from \"" << url << "\"" << std::endl;

--- a/src/client/clientmedia.h
+++ b/src/client/clientmedia.h
@@ -101,6 +101,7 @@ private:
 	struct RemoteServerStatus {
 		std::string baseurl;
 		s32 active_count;
+		bool supports_bulk_download;
 	};
 
 	void initialStep(Client *client);
@@ -116,7 +117,7 @@ private:
 			Client *client);
 
 	std::string serializeRequiredHashSet();
-	static void deSerializeHashSet(const std::string &data,
+	static bool deSerializeHashSet(const std::string &data,
 			std::set<std::string> &result);
 
 	// Maps filename to file status
@@ -145,7 +146,7 @@ private:
 	s32 m_httpfetch_active = 0;
 	s32 m_httpfetch_active_limit = 0;
 	s32 m_outstanding_hash_sets = 0;
-	std::unordered_map<unsigned long, std::string> m_remote_file_transfers;
+	std::unordered_map<unsigned long, std::vector<std::string>> m_remote_file_transfers;
 
 	// All files up to this name have either been received from a
 	// remote server or failed on all remote servers, so those files


### PR DESCRIPTION
Most media files are very tiny, so the overhead of one HTTP request per file (especially the round trip) when using remote media slows things down a lot.

I've made it download 50 files per HTTP request. I'm not sure what this should be, I get most of the performance improvement with 15. Keep in mind that it is performing multiple HTTP requests in parallel on top of this, so the maximum number of files being fetched at once would be 50 × 8 = 400.

It doesn't know the file sizes when it requests them, so it would be possible (in theory) for it to request the 50 largest files at once, although the only downside to this would be (potentially) higher memory usage and maybe less data in the cache if the player closes the app partway through the large download.

The old remote media protocol is still supported, since I'm guessing it would be desirable when joining Luanti servers that want to offload their bandwidth to a separate media server.