### PR TITLE
Make /setspawn save yaw and pitch

### DIFF
--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -1191,8 +1191,10 @@ core.register_chatcommand("spawn", {
 
 		if spawnpoint then
 			player:set_pos(spawnpoint)
-			player:set_look_horizontal(yaw)
-			player:set_look_vertical(pitch)
+			if yaw and pitch then
+				player:set_look_horizontal(yaw)
+				player:set_look_vertical(pitch)
+			end
 			return true, "Teleporting to spawn..."
 		else
 			return false, "The spawn point is not set!"

--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -1183,10 +1183,16 @@ core.register_chatcommand("spawn", {
 		if not player then
 			return false
 		end
-		local spawnpoint = core.setting_get_pos("static_spawnpoint") or
-			core.get_world_spawnpoint()
+		local spawnpoint = core.setting_get_pos("static_spawnpoint")
+		local yaw, pitch
+		if not spawnpoint then
+			spawnpoint, yaw, pitch = core.get_world_spawnpoint()
+		end
+
 		if spawnpoint then
 			player:set_pos(spawnpoint)
+			player:set_look_horizontal(yaw)
+			player:set_look_vertical(pitch)
 			return true, "Teleporting to spawn..."
 		else
 			return false, "The spawn point is not set!"
@@ -1214,7 +1220,10 @@ core.register_chatcommand("setspawn", {
 			core.settings:write()
 		end
 
-		core.set_world_spawnpoint(pos)
+		local yaw = math.round(player:get_look_horizontal() * 100) / 100
+		local pitch = math.round(player:get_look_vertical() * 100) / 100
+
+		core.set_world_spawnpoint(pos, yaw, pitch)
 
 		return true, "The spawn point has been set to " .. core.pos_to_string(pos)
 	end

--- a/builtin/game/static_spawn.lua
+++ b/builtin/game/static_spawn.lua
@@ -9,13 +9,21 @@ if static_spawnpoint_string and
 end
 
 local function put_player_in_spawn(player_obj)
-	local static_spawnpoint = core.setting_get_pos("static_spawnpoint") or core.get_world_spawnpoint()
+	local static_spawnpoint = core.setting_get_pos("static_spawnpoint")
+	local yaw, pitch
+	if not static_spawnpoint then
+		static_spawnpoint, yaw, pitch = core.get_world_spawnpoint()
+	end
 	if not static_spawnpoint then
 		return false
 	end
 	core.log("action", "Moving " .. player_obj:get_player_name() ..
 		" to spawnpoint at " .. core.pos_to_string(static_spawnpoint))
 	player_obj:set_pos(static_spawnpoint)
+	if yaw and pitch then
+		player_obj:set_look_horizontal(yaw)
+		player_obj:set_look_vertical(pitch)
+	end
 	return true
 end
 

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -5363,12 +5363,12 @@ Environment access
     * The spawn level returned is for a player spawn in unmodified terrain.
     * The spawn level is intentionally above terrain level to cope with
       full-node biome 'dust' nodes.
- * `minetest.set_world_spawnpoint([pos])`
+ * `minetest.set_world_spawnpoint([pos, yaw, pitch])`
     * Sets the world-specific spawnpoint to pos (or `nil` to reset).
     * If `static_spawnpoint` is specified in multicraft.conf, the
       world-specific spawnpoint will be ignored.
  * `minetest.get_world_spawnpoint()`
-    * Returns the world-specific spawnpoint.
+    * Returns the world-specific spawnpoint (pos, yaw, pitch).
 
 Mod channels
 ------------

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -1430,11 +1430,14 @@ int ModApiEnvMod::l_get_world_spawnpoint(lua_State * L)
 	GET_ENV_PTR;
 
 	v3f spawnpoint;
-	if (!env->getWorldSpawnpoint(spawnpoint))
+	float yaw, pitch;
+	if (!env->getWorldSpawnpoint(spawnpoint, &yaw, &pitch))
 		return 0;
 
 	push_v3f(L, spawnpoint);
-	return 1;
+	lua_pushnumber(L, yaw);
+	lua_pushnumber(L, pitch);
+	return 3;
 }
 
 // set_world_spawnpoint(spawnpoint)
@@ -1442,11 +1445,13 @@ int ModApiEnvMod::l_set_world_spawnpoint(lua_State * L)
 {
 	GET_ENV_PTR;
 
-	if (lua_isnil(L, 1)) {
+	if (lua_isnoneornil(L, 1)) {
 		env->resetWorldSpawnpoint();
 	} else {
 		const v3f spawnpoint = read_v3f(L, 1);
-		env->setWorldSpawnpoint(spawnpoint);
+		const float yaw = lua_isnoneornil(L, 2) ? 0.0f : readParam<float>(L, 2);
+		const float pitch = lua_isnoneornil(L, 3) ? 0.0f : readParam<float>(L, 3);
+		env->setWorldSpawnpoint(spawnpoint, yaw, pitch);
 	}
 
 	return 0;

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -648,8 +648,11 @@ void ServerEnvironment::saveMeta()
 		m_lbm_mgr.createIntroductionTimesString());
 	args.setU64("day_count", m_day_count);
 
-	if (m_has_world_spawnpoint)
+	if (m_has_world_spawnpoint) {
 		args.setV3F("static_spawnpoint", m_world_spawnpoint);
+		args.setFloat("static_spawnpoint_yaw", m_world_spawnpoint_yaw);
+		args.setFloat("static_spawnpoint_pitch", m_world_spawnpoint_pitch);
+	}
 
 	args.writeLines(ss);
 
@@ -726,6 +729,10 @@ void ServerEnvironment::loadMeta()
 		args.getU64("day_count") : 0;
 
 	m_has_world_spawnpoint = args.getV3FNoEx("static_spawnpoint", m_world_spawnpoint);
+	if (m_has_world_spawnpoint) {
+		args.getFloatNoEx("static_spawnpoint_yaw", m_world_spawnpoint_yaw);
+		args.getFloatNoEx("static_spawnpoint_pitch", m_world_spawnpoint_pitch);
+	}
 }
 
 /**

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -648,11 +648,12 @@ void ServerEnvironment::saveMeta()
 		m_lbm_mgr.createIntroductionTimesString());
 	args.setU64("day_count", m_day_count);
 
-	if (m_has_world_spawnpoint) {
-		args.setV3F("static_spawnpoint", m_world_spawnpoint);
-		args.setFloat("static_spawnpoint_yaw", m_world_spawnpoint_yaw);
-		args.setFloat("static_spawnpoint_pitch", m_world_spawnpoint_pitch);
-	}
+	if (m_world_spawnpoint.has_value())
+		args.setV3F("static_spawnpoint", m_world_spawnpoint.value());
+	if (m_world_spawnpoint_yaw.has_value())
+		args.setFloat("static_spawnpoint_yaw", m_world_spawnpoint_yaw.value());
+	if (m_world_spawnpoint_pitch.has_value())
+		args.setFloat("static_spawnpoint_pitch", m_world_spawnpoint_pitch.value());
 
 	args.writeLines(ss);
 
@@ -728,10 +729,14 @@ void ServerEnvironment::loadMeta()
 	m_day_count = args.exists("day_count") ?
 		args.getU64("day_count") : 0;
 
-	m_has_world_spawnpoint = args.getV3FNoEx("static_spawnpoint", m_world_spawnpoint);
-	if (m_has_world_spawnpoint) {
-		args.getFloatNoEx("static_spawnpoint_yaw", m_world_spawnpoint_yaw);
-		args.getFloatNoEx("static_spawnpoint_pitch", m_world_spawnpoint_pitch);
+	try {
+		// static_spawnpoint must be read before yaw and pitch as yaw/pitch may
+		// not exist.
+		m_world_spawnpoint = args.getV3F("static_spawnpoint");
+		m_world_spawnpoint_yaw = args.getFloat("static_spawnpoint_yaw");
+		m_world_spawnpoint_pitch = args.getFloat("static_spawnpoint_pitch");
+	} catch (SettingNotFoundException &e) {
+		// The spawnpoint or yaw/pitch does not exist, this is expected
 	}
 }
 

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -27,6 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/numeric.h"
 #include <set>
 #include <random>
+#include <optional>
 
 class IGameDef;
 class ServerMap;
@@ -370,26 +371,30 @@ public:
 	 */
 	void loadDefaultMeta();
 
-	bool getWorldSpawnpoint(v3f &spawnpoint, float *yaw_to = nullptr, float *pitch_to = nullptr) {
-		if (m_has_world_spawnpoint) {
-			spawnpoint = m_world_spawnpoint;
+	bool getWorldSpawnpoint(v3f &spawnpoint,
+			std::optional<float> *yaw_to = nullptr,
+			std::optional<float> *pitch_to = nullptr) {
+		if (m_world_spawnpoint.has_value()) {
+			spawnpoint = m_world_spawnpoint.value();
 			if (yaw_to != nullptr)
 				*yaw_to = m_world_spawnpoint_yaw;
 			if (pitch_to != nullptr)
 				*pitch_to = m_world_spawnpoint_pitch;
 		}
-		return m_has_world_spawnpoint;
+		return m_world_spawnpoint.has_value();
 	}
 
-	void setWorldSpawnpoint(const v3f &spawnpoint, const float yaw, const float pitch) {
+	void setWorldSpawnpoint(const v3f &spawnpoint,
+			const std::optional<float> yaw, const std::optional<float> pitch) {
 		m_world_spawnpoint = spawnpoint;
 		m_world_spawnpoint_yaw = yaw;
 		m_world_spawnpoint_pitch = pitch;
-		m_has_world_spawnpoint = true;
 	}
 
 	void resetWorldSpawnpoint() {
-		m_has_world_spawnpoint = false;
+		m_world_spawnpoint = std::nullopt;
+		m_world_spawnpoint_yaw = std::nullopt;
+		m_world_spawnpoint_pitch = std::nullopt;
 	}
 
 private:
@@ -500,10 +505,9 @@ private:
 	std::unordered_map<u32, float> m_particle_spawners;
 	std::unordered_map<u32, u16> m_particle_spawner_attachments;
 
-	v3f m_world_spawnpoint = v3f(0.f, 0.f, 0.f);
-	float m_world_spawnpoint_yaw = 0.0f;
-	float m_world_spawnpoint_pitch = 0.0f;
-	bool m_has_world_spawnpoint = false;
+	std::optional<v3f> m_world_spawnpoint = v3f(0.f, 0.f, 0.f);
+	std::optional<float> m_world_spawnpoint_yaw = std::nullopt;
+	std::optional<float> m_world_spawnpoint_pitch = std::nullopt;
 
 	ServerActiveObject* createSAO(ActiveObjectType type, v3f pos, const std::string &data);
 };

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -370,14 +370,21 @@ public:
 	 */
 	void loadDefaultMeta();
 
-	bool getWorldSpawnpoint(v3f &spawnpoint) {
-		if (m_has_world_spawnpoint)
+	bool getWorldSpawnpoint(v3f &spawnpoint, float *yaw_to = nullptr, float *pitch_to = nullptr) {
+		if (m_has_world_spawnpoint) {
 			spawnpoint = m_world_spawnpoint;
+			if (yaw_to != nullptr)
+				*yaw_to = m_world_spawnpoint_yaw;
+			if (pitch_to != nullptr)
+				*pitch_to = m_world_spawnpoint_pitch;
+		}
 		return m_has_world_spawnpoint;
 	}
 
-	void setWorldSpawnpoint(const v3f &spawnpoint) {
+	void setWorldSpawnpoint(const v3f &spawnpoint, const float yaw, const float pitch) {
 		m_world_spawnpoint = spawnpoint;
+		m_world_spawnpoint_yaw = yaw;
+		m_world_spawnpoint_pitch = pitch;
 		m_has_world_spawnpoint = true;
 	}
 
@@ -494,6 +501,8 @@ private:
 	std::unordered_map<u32, u16> m_particle_spawner_attachments;
 
 	v3f m_world_spawnpoint = v3f(0.f, 0.f, 0.f);
+	float m_world_spawnpoint_yaw = 0.0f;
+	float m_world_spawnpoint_pitch = 0.0f;
 	bool m_has_world_spawnpoint = false;
 
 	ServerActiveObject* createSAO(ActiveObjectType type, v3f pos, const std::string &data);


### PR DESCRIPTION
I wonder whether /setspawn should be a mod and not an engine feature.

Note that existing spawnpoints set with `/setspawn` will have a yaw and pitch of 0, did I need to make them just not set yaw/pitch?