### PR TITLE
Allow logging in with a player name case insensitively

### DIFF
--- a/builtin/game/auth.lua
+++ b/builtin/game/auth.lua
@@ -128,6 +128,28 @@ core.builtin_auth_handler = {
 		end
 		return pairs(names)
 	end,
+	get_canonical_name = function(name)
+		local name_lower = name:lower()
+		if name_lower == name:upper() then
+			-- Name has no uppercase/lowercase versions, no need to do anything
+			return name
+		end
+
+		-- Fast path for existing players with the correct case provided
+		if core_auth.read(name) then
+			return name
+		end
+
+		-- Search for the player name case-insensitively
+		-- TODO: Cache this?
+		for _, n in ipairs(core_auth.list_names()) do
+			if n:lower() == name_lower then
+				return n
+			end
+		end
+
+		return name
+	end,
 }
 
 core.register_on_prejoinplayer(function(name, ip)

--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -6544,6 +6544,8 @@ object you are working with still exists.
 #### Player only (no-op for other objects)
 
 * `get_player_name()`: returns `""` if is not a player
+* `get_uncanonical_player_name()`: Returns the name that the client thinks the player has.
+    * For internal use only, subject to removal or breakage.
 * `get_player_velocity()`: **DEPRECATED**, use get_velocity() instead.
   table {x, y, z} representing the player's instantaneous velocity in nodes/s
 * `add_player_velocity(vel)`: **DEPRECATED**, use add_velocity(vel) instead.

--- a/src/clientiface.cpp
+++ b/src/clientiface.cpp
@@ -781,14 +781,15 @@ ClientState ClientInterface::getClientState(session_t peer_id)
 	return n->second->getState();
 }
 
-void ClientInterface::setPlayerName(session_t peer_id, const std::string &name)
+void ClientInterface::setPlayerName(session_t peer_id, const std::string &name,
+		const std::string &uncanonical_name)
 {
 	RecursiveMutexAutoLock clientslock(m_clients_mutex);
 	RemoteClientMap::iterator n = m_clients.find(peer_id);
 	// The client may not exist; clients are immediately removed if their
 	// access is denied, and this event occurs later then.
 	if (n != m_clients.end())
-		n->second->setName(name);
+		n->second->setName(name, uncanonical_name);
 }
 
 void ClientInterface::DeleteClient(session_t peer_id)

--- a/src/clientiface.h
+++ b/src/clientiface.h
@@ -309,8 +309,12 @@ public:
 	ClientState getState() const { return m_state; }
 
 	std::string getName() const { return m_name; }
+	std::string getUncanonicalName() const { return m_uncanonical_name; }
 
-	void setName(const std::string &name) { m_name = name; }
+	void setName(const std::string &name, const std::string &uncanonical_name) {
+		m_name = name;
+		m_uncanonical_name = uncanonical_name;
+	}
 
 	/* update internal client state */
 	void notifyEvent(ClientStateEvent event);
@@ -434,6 +438,11 @@ private:
 	std::string m_name = "";
 
 	/*
+		Name that the client provided on initial connection
+	*/
+	std::string m_uncanonical_name = "";
+
+	/*
 		client information
 	*/
 	u8 m_version_major = 0;
@@ -502,7 +511,8 @@ public:
 	ClientState getClientState(session_t peer_id);
 
 	/* set client playername */
-	void setPlayerName(session_t peer_id, const std::string &name);
+	void setPlayerName(session_t peer_id, const std::string &name,
+			const std::string &uncanonical_name);
 
 	/* get protocol version of client */
 	u16 getProtocolVersion(session_t peer_id);

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -158,6 +158,12 @@ void Server::handleCommand_Init(NetworkPacket* pkt)
 	*/
 	const char* playername = playerName.c_str();
 
+	// Get the canonical casing before the checks, but only if it's valid (so
+	// we check the name before and after getCanonicalPlayerName)
+	if (playerName.size() > 0 && playerName.size() <= PLAYERNAME_SIZE &&
+			string_allowed(playerName, PLAYERNAME_ALLOWED_CHARS))
+		playerName = m_script->getCanonicalPlayerName(playerName);
+
 	size_t pns = playerName.size();
 	if (pns == 0 || pns > PLAYERNAME_SIZE) {
 		actionstream << "Server: Player with " <<
@@ -175,7 +181,6 @@ void Server::handleCommand_Init(NetworkPacket* pkt)
 	}
 
 	m_clients.setPlayerName(peer_id, playername);
-	//TODO (later) case insensitivity
 
 	std::string legacyPlayerNameCasing = playerName;
 

--- a/src/remoteplayer.cpp
+++ b/src/remoteplayer.cpp
@@ -36,7 +36,8 @@ bool RemotePlayer::m_setting_cache_loaded = false;
 float RemotePlayer::m_setting_chat_message_limit_per_10sec = 0.0f;
 u16 RemotePlayer::m_setting_chat_message_limit_trigger_kick = 0;
 
-RemotePlayer::RemotePlayer(const char *name, IItemDefManager *idef):
+RemotePlayer::RemotePlayer(const char *name, IItemDefManager *idef,
+		const std::string &uncanonical_name):
 	Player(name, idef)
 {
 	if (!RemotePlayer::m_setting_cache_loaded) {
@@ -81,6 +82,8 @@ RemotePlayer::RemotePlayer(const char *name, IItemDefManager *idef):
 	m_sun_params = sky_defaults.getSunDefaults();
 	m_moon_params = sky_defaults.getMoonDefaults();
 	m_star_params = sky_defaults.getStarDefaults();
+
+	m_uncanonical_name = uncanonical_name.empty() ? name : uncanonical_name;
 }
 
 

--- a/src/remoteplayer.h
+++ b/src/remoteplayer.h
@@ -41,7 +41,8 @@ class RemotePlayer : public Player
 	friend class PlayerDatabaseFiles;
 
 public:
-	RemotePlayer(const char *name, IItemDefManager *idef);
+	RemotePlayer(const char *name, IItemDefManager *idef,
+			const std::string &uncanonical_name = "");
 	virtual ~RemotePlayer() = default;
 
 	PlayerSAO *getPlayerSAO() { return m_sao; }
@@ -137,6 +138,8 @@ public:
 
 	void setPeerId(session_t peer_id) { m_peer_id = peer_id; }
 
+	std::string getUncanonicalName() { return m_uncanonical_name; }
+
 	void onSuccessfulSave();
 
 private:
@@ -164,4 +167,5 @@ private:
 	StarParams m_star_params;
 
 	session_t m_peer_id = PEER_ID_INEXISTENT;
+	std::string m_uncanonical_name;
 };

--- a/src/script/cpp_api/s_server.cpp
+++ b/src/script/cpp_api/s_server.cpp
@@ -137,6 +137,25 @@ bool ScriptApiServer::setPassword(const std::string &playername,
 	return lua_toboolean(L, -1);
 }
 
+// Returns the provided player name with proper casing
+std::string ScriptApiServer::getCanonicalPlayerName(const std::string &playername)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	int error_handler = PUSH_ERROR_HANDLER(L);
+	getAuthHandler();
+	lua_getfield(L, -1, "get_canonical_name");
+	// No-op if it doesn't exist for compatibility with 3rd-party auth mods
+	if (lua_type(L, -1) != LUA_TFUNCTION)
+		return playername;
+	lua_pushstring(L, playername.c_str());
+	PCALL_RES(lua_pcall(L, 1, 1, error_handler));
+	lua_remove(L, -2); // Remove auth handler
+	lua_remove(L, error_handler);
+
+	return luaL_checkstring(L, -1);
+}
+
 bool ScriptApiServer::on_chat_message(const std::string &name,
 		const std::string &message)
 {

--- a/src/script/cpp_api/s_server.h
+++ b/src/script/cpp_api/s_server.h
@@ -49,6 +49,7 @@ public:
 		const std::string &password);
 	bool setPassword(const std::string &playername,
 		const std::string &password);
+	std::string getCanonicalPlayerName(const std::string &playername);
 
 	// Note that this calls collectgarbage() first.
 	size_t getMemoryUsageKB();

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1042,6 +1042,22 @@ int ObjectRef::l_get_player_name(lua_State *L)
 	return 1;
 }
 
+// get_uncanonical_player_name(self)
+int ObjectRef::l_get_uncanonical_player_name(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkobject(L, 1);
+	RemotePlayer *player = getplayer(ref);
+	if (player == nullptr) {
+		lua_pushlstring(L, "", 0);
+		return 1;
+	}
+
+	const std::string name = player->getUncanonicalName();
+	lua_pushstring(L, name.c_str());
+	return 1;
+}
+
 // get_look_dir(self)
 int ObjectRef::l_get_look_dir(lua_State *L)
 {
@@ -2377,6 +2393,7 @@ luaL_Reg ObjectRef::methods[] = {
 	// Player-only
 	luamethod(ObjectRef, is_player),
 	luamethod(ObjectRef, get_player_name),
+	luamethod(ObjectRef, get_uncanonical_player_name),
 	luamethod(ObjectRef, get_look_dir),
 	luamethod(ObjectRef, get_look_pitch),
 	luamethod(ObjectRef, get_look_yaw),

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -202,6 +202,9 @@ private:
 	// get_player_name(self)
 	static int l_get_player_name(lua_State *L);
 
+	// get_uncanonical_player_name(self)
+	static int l_get_uncanonical_player_name(lua_State *L);
+
 	// get_fov(self)
 	static int l_get_fov(lua_State *L);
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2040,8 +2040,18 @@ void Server::SendActiveObjectRemoveAdd(RemoteClient *client, PlayerSAO *playersa
 		writeU8((u8*)buf, type);
 		data.append(buf, 1);
 
-		data.append(serializeString32(
-			obj->getClientInitializationData(client->net_proto_version)));
+		if (obj == playersao) {
+			// Use the client-provided player name when sending a player their
+			// own object so that the client knows that it's the local player
+			data.append(serializeString32(
+				playersao->getClientInitializationDataWithPlayerName(
+					client->net_proto_version, client->getUncanonicalName()
+				)
+			));
+		} else {
+			data.append(serializeString32(
+				obj->getClientInitializationData(client->net_proto_version)));
+		}
 
 		// Add to known objects
 		client->m_known_objects.insert(id);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1068,7 +1068,8 @@ PlayerSAO* Server::StageTwoClientInit(session_t peer_id)
 		RemoteClient* client = m_clients.lockedGetClientNoEx(peer_id, CS_InitDone);
 		if (client) {
 			playername = client->getName();
-			playersao = emergePlayer(playername.c_str(), peer_id, client->net_proto_version);
+			playersao = emergePlayer(playername.c_str(), peer_id,
+					client->net_proto_version, client->getUncanonicalName());
 		}
 	} catch (std::exception &e) {
 		m_clients.unlock();
@@ -3794,7 +3795,8 @@ void Server::requestShutdown(const std::string &msg, bool reconnect, float delay
 	m_shutdown_state.trigger(delay, msg, reconnect);
 }
 
-PlayerSAO* Server::emergePlayer(const char *name, session_t peer_id, u16 proto_version)
+PlayerSAO* Server::emergePlayer(const char *name, session_t peer_id, u16 proto_version,
+		const std::string &uncanonical_name)
 {
 	/*
 		Try to get an existing player
@@ -3817,7 +3819,7 @@ PlayerSAO* Server::emergePlayer(const char *name, session_t peer_id, u16 proto_v
 	}
 
 	if (!player) {
-		player = new RemotePlayer(name, idef());
+		player = new RemotePlayer(name, idef(), uncanonical_name);
 	}
 
 	bool newplayer = false;

--- a/src/server.h
+++ b/src/server.h
@@ -521,7 +521,8 @@ private:
 
 		Call with env and con locked.
 	*/
-	PlayerSAO *emergePlayer(const char *name, session_t peer_id, u16 proto_version);
+	PlayerSAO *emergePlayer(const char *name, session_t peer_id, u16 proto_version,
+			const std::string &uncanonical_name);
 
 	void handlePeerChanges();
 

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -106,11 +106,17 @@ void PlayerSAO::removingFromEnvironment()
 
 std::string PlayerSAO::getClientInitializationData(u16 protocol_version)
 {
+	return getClientInitializationDataWithPlayerName(protocol_version, m_player->getName());
+}
+
+std::string PlayerSAO::getClientInitializationDataWithPlayerName(u16 protocol_version,
+		const std::string &playername)
+{
 	std::ostringstream os(std::ios::binary);
 
 	// Protocol >= 15
 	writeU8(os, 1); // version
-	os << serializeString16(m_player->getName()); // name
+	os << serializeString16(playername); // name
 	writeU8(os, 1); // is_player
 	writeS16(os, getId()); // id
 	writeV3F32(os, m_base_position);

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -85,6 +85,8 @@ public:
 	bool isStaticAllowed() const { return false; }
 	bool shouldUnload() const { return false; }
 	std::string getClientInitializationData(u16 protocol_version);
+	std::string getClientInitializationDataWithPlayerName(u16 protocol_version,
+			const std::string &playername);
 	void getStaticData(std::string *result) const;
 	void step(float dtime, bool send_recommended);
 	void setBasePosition(const v3f &position);

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -85,8 +85,8 @@ public:
 	bool isStaticAllowed() const { return false; }
 	bool shouldUnload() const { return false; }
 	std::string getClientInitializationData(u16 protocol_version);
-	std::string getClientInitializationDataWithPlayerName(u16 protocol_version,
-			const std::string &playername);
+	std::string getClientInitializationDataWithPlayerName(
+			u16 protocol_version, const std::string &playername);
 	void getStaticData(std::string *result) const;
 	void step(float dtime, bool send_recommended);
 	void setBasePosition(const v3f &position);


### PR DESCRIPTION
The network protocol does already has the server sending back a player name to the client, except that the client does nothing with it, so I've had to implement a couple of hacks to get this working without client changes.

This will not work with legacy password hashes, although I don't think any worlds are old enough for that to be a problem, and in case there is an issue you just need to log in with the correct casing and optionally change your password.

Also, you could probably rename players completely with this PR using the new Lua API. I'm not sure about the performance of this API though, since it iterates through the entire player list, but then that's also done to check for correct casing anyway.