### PR TITLE
Add get_free_ram() API

### DIFF
--- a/doc/menu_lua_api.txt
+++ b/doc/menu_lua_api.txt
@@ -49,7 +49,9 @@ core.open_dir(path)
 core.get_version() (possible in async calls)
 ^ returns current core version
 core.get_system_ram()
-^ returns system memory in MB
+^ returns system memory in MiB
+core.get_free_ram()
+^ returns free (available) memory in MiB
 core.copy_to_clipboard(text)
 ^ Copies text to the clipboard
 

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -785,7 +785,7 @@ double getAvailableSystemMemory()
 	MEMORYSTATUSEX status;
 	status.dwLength = sizeof(status);
 	GlobalMemoryStatusEx(&status);
-	return static_cast<double>(status.ullAvailPhys) / 1024 / 1024;
+	return (double)status.ullAvailPhys / 1024 / 1024;
 
 //// Linux
 #elif defined(__linux__)
@@ -798,19 +798,28 @@ double getAvailableSystemMemory()
 			std::string available;
 			std::istringstream iss(line);
 			iss >> label >> available;
-			return static_cast<double>(stoi(available)) / 1024;
+			return (double)stoi(available) / 1024;
 		}
 	}
 
-	return -1;
-
-//// TODO: Mac OS X, Darwin
-// #elif defined(__APPLE__)
-
-#else
-	return -1;
+//// Darwin
+#elif defined(__APPLE__)
+	vm_size_t page_size;
+	host_page_size(mach_host_self(), &page_size);
+	vm_statistics64_data_t vm_stats;
+	mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
+	if (host_statistics64(mach_host_self(), HOST_VM_INFO64,
+			(host_info64_t)&vm_stats, &count) == KERN_SUCCESS) {
+		// Free, inactive and speculative pages can be reclaimed on demand
+		u64 free_memory = ((u64)vm_stats.free_count +
+				(u64)vm_stats.inactive_count +
+				(u64)vm_stats.speculative_count) * (u64)page_size;
+		return (double)free_memory / 1024 / 1024;
+	}
 
 #endif
+
+	return -1;
 }
 
 bool open_directory(const std::string &path)

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -777,6 +777,43 @@ int getTotalSystemMemory()
 #endif
 }
 
+double getAvailableSystemMemory()
+{
+
+//// Windows
+#if defined(_WIN32)
+	// TODO: Test this (https://stackoverflow.com/a/2513561)
+	MEMORYSTATUSEX status;
+	status.dwLength = sizeof(status);
+	GlobalMemoryStatusEx(&status);
+	return static_cast<double>(status.ullAvailPhys) / 1024 / 1024;
+
+//// Linux
+#elif defined(__linux__)
+	// The "free" command also reads /proc/meminfo
+	std::ifstream infile("/proc/meminfo");
+	std::string line;
+	while (std::getline(infile, line)) {
+		if (str_starts_with(line, "MemAvailable:")) {
+			std::string label;
+			std::string available;
+			std::istringstream iss(line);
+			iss >> label >> available;
+			return static_cast<double>(stoi(available)) / 1024;
+		}
+	}
+
+	return -1;
+
+//// TODO: Mac OS X, Darwin
+// #elif defined(__APPLE__)
+
+#else
+	return -1;
+
+#endif
+}
+
 bool open_directory(const std::string &path)
 {
 	if (!fs::IsDir(path)) {

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -782,7 +782,6 @@ double getAvailableSystemMemory()
 
 //// Windows
 #if defined(_WIN32)
-	// TODO: Test this (https://stackoverflow.com/a/2513561)
 	MEMORYSTATUSEX status;
 	status.dwLength = sizeof(status);
 	GlobalMemoryStatusEx(&status);

--- a/src/porting.h
+++ b/src/porting.h
@@ -371,6 +371,12 @@ NORETURN void finishGame(const std::string &exc);
 
 int getTotalSystemMemory();
 
+/**
+ * Gets available (free) device memory in MiB (for parity with getTotalSystemMemory)
+ */
+
+double getAvailableSystemMemory();
+
 bool open_directory(const std::string &path);
 
 } // namespace porting

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -617,6 +617,15 @@ int ModApiUtil::l_get_system_ram(lua_State *L)
 	return 1;
 }
 
+int ModApiUtil::l_get_free_ram(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	const double res = porting::getAvailableSystemMemory();
+	lua_pushnumber(L, res);
+
+	return 1;
+}
+
 int ModApiUtil::l_copy_to_clipboard(lua_State *L)
 {
 	IOSOperator *op = RenderingEngine::get_raw_device()->getOSOperator();
@@ -728,6 +737,7 @@ void ModApiUtil::Initialize(lua_State *L, int top)
 	API_FCT(upgrade);
 	API_FCT(get_secret_key);
 	API_FCT(get_system_ram);
+	API_FCT(get_free_ram);
 #endif
 
 	LuaSettings::create(L, g_settings, g_settings_path);
@@ -757,6 +767,7 @@ void ModApiUtil::InitializeClient(lua_State *L, int top)
 
 	API_FCT(get_screen_info);
 	API_FCT(get_system_ram);
+	API_FCT(get_free_ram);
 	API_FCT(copy_to_clipboard);
 	API_FCT(get_translated_string);
 	API_FCT(load_translation);
@@ -806,6 +817,7 @@ void ModApiUtil::InitializeMainMenu(lua_State *L, int top) {
 	API_FCT(get_secret_key);
 	API_FCT(get_screen_info);
 	API_FCT(get_system_ram);
+	API_FCT(get_free_ram);
 	API_FCT(copy_to_clipboard);
 	API_FCT(get_translated_string);
 	API_FCT(load_translation);

--- a/src/script/lua_api/l_util.h
+++ b/src/script/lua_api/l_util.h
@@ -113,6 +113,9 @@ private:
 	// get_system_ram()
 	static int l_get_system_ram(lua_State *L);
 
+	// get_free_ram()
+	static int l_get_free_ram(lua_State *L);
+
 	// copy_to_clipboard(text)
 	static int l_copy_to_clipboard(lua_State *L);
 


### PR DESCRIPTION
Requires Linux 3.14+ (released in 2014, so probably good enough) or Windows (tested under Wine and seems to work)

macOS seems even more complicated, I haven't tried implementing it since I will probably make a mistake and won't be able to test it