### PR TITLE
Add on_browser_closed callback

### DIFF
--- a/Android/app/src/main/java/com/multicraft/game/GameActivity.kt
+++ b/Android/app/src/main/java/com/multicraft/game/GameActivity.kt
@@ -73,6 +73,9 @@ class GameActivity : SDLActivity() {
 	private var splashView: View? = null
 	private var isExtract: Boolean = false
 	private var messageReturnValue = ""
+	// Set just before launching an embedded browser tab; cleared in onResume.
+	private var browserOpen: Boolean = false
+	private var browserUrl: String? = null
 	private var hasKeyboard = false
 	override fun getLibraries() = arrayOf("MultiCraft")
 
@@ -123,6 +126,18 @@ class GameActivity : SDLActivity() {
 
 	override fun onResume() {
 		super.onResume()
+		// When an embedded browser tab closes, Android returns here.
+		if (browserOpen) {
+			browserOpen = false
+			val url = browserUrl
+			browserUrl = null
+			if (url != null) {
+				try {
+					update("_browser_closed", url)
+				} catch (_: UnsatisfiedLinkError) {
+				}
+			}
+		}
 		if (hasKeyboard) {
 			try {
 				keyboardEvent(true)
@@ -321,6 +336,8 @@ class GameActivity : SDLActivity() {
 			.setStartAnimations(this, R.anim.slide_in_bottom, R.anim.slide_out_top)
 			.setExitAnimations(this, R.anim.slide_in_top, R.anim.slide_out_bottom)
 			.build()
+		browserUrl = uri
+		browserOpen = true
 		builder.launchUrl(this, uri.toUri())
 
 		return true

--- a/builtin/client/register.lua
+++ b/builtin/client/register.lua
@@ -86,3 +86,13 @@ core.registered_on_pause_menu_open, core.register_on_pause_menu_open = make_regi
 core.registered_on_tab, core.register_on_tab = make_registration()
 core.registered_on_hud_button_press, core.register_on_hud_button_press = make_registration()
 core.registered_on_update, core.register_on_update = make_registration()
+core.registered_on_browser_closed, core.register_on_browser_closed = make_registration()
+
+-- Route internal update events to dedicated callbacks.
+core.register_on_update(function(key, value)
+    if key == "_browser_closed" then
+        for _, func in ipairs(core.registered_on_browser_closed) do
+            func(value)
+        end
+    end
+end)

--- a/builtin/mainmenu/register.lua
+++ b/builtin/mainmenu/register.lua
@@ -8,6 +8,16 @@ end
 
 core.registered_globalsteps, core.register_globalstep = make_registration()
 core.registered_on_update, core.register_on_update = make_registration()
+core.registered_on_browser_closed, core.register_on_browser_closed = make_registration()
+
+-- Route internal update events to dedicated callbacks.
+core.register_on_update(function(key, value)
+    if key == "_browser_closed" then
+        for _, func in ipairs(core.registered_on_browser_closed) do
+            func(value)
+        end
+    end
+end)
 
 function core.update_handler(...)
     for _, func in ipairs(core.registered_on_update) do


### PR DESCRIPTION
Unfortunately I wasn't able to test this, I tried installing the APK from actions and just get a blue screen when I launch the app. But this is what I had in mind

I decided to reuse the `update` mechanism to pass the browser closed message back.

This is a separate callback so that the main menu code can still do things in the background while we wait for the browser to be closed.

<sup>This is AI generated but is effectively what I wanted</sup>